### PR TITLE
Extract OpenAPI docs into Go doc comments

### DIFF
--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -96,6 +96,23 @@ func TestAnalyzePetstore(t *testing.T) {
 		}
 	}
 
+	// Verify type-level description.
+	if pet.Description != "A pet in the store" {
+		t.Errorf("Pet.Description = %q, want %q", pet.Description, "A pet in the store")
+	}
+
+	// Verify field-level descriptions are extracted from property schemas.
+	if idField, ok := fieldMap["id"]; ok {
+		if idField.Description != "The unique identifier for the pet" {
+			t.Errorf("Pet.id.Description = %q, want %q", idField.Description, "The unique identifier for the pet")
+		}
+	}
+	if nameField, ok := fieldMap["name"]; ok {
+		if nameField.Description != "The display name of the pet" {
+			t.Errorf("Pet.name.Description = %q, want %q", nameField.Description, "The display name of the pet")
+		}
+	}
+
 	// tag is type: ["string", "null"] -- should be nullable.
 	if tagField, ok := fieldMap["tag"]; ok {
 		if tagField.Type != "*string" {
@@ -118,6 +135,9 @@ func TestAnalyzePetstore(t *testing.T) {
 	}
 	if len(petStatus.EnumValues) != 3 {
 		t.Errorf("PetStatus: expected 3 enum values, got %d", len(petStatus.EnumValues))
+	}
+	if petStatus.Description != "The current status of the pet in the store" {
+		t.Errorf("PetStatus.Description = %q, want %q", petStatus.Description, "The current status of the pet in the store")
 	}
 
 	// PetList should be a struct with an items field that is an array.
@@ -407,6 +427,18 @@ func TestAnalyzePetstore_FieldDetails(t *testing.T) {
 		}
 	} else {
 		t.Error("Error missing message field")
+	}
+
+	// Verify field descriptions are extracted from property schemas.
+	if nameField, ok := fieldMap["name"]; ok {
+		if nameField.Description != "The name of the pet to create" {
+			t.Errorf("CreatePetRequest.name.Description = %q, want %q", nameField.Description, "The name of the pet to create")
+		}
+	}
+	if tagField, ok := fieldMap["tag"]; ok {
+		if tagField.Description != "An optional tag for the pet" {
+			t.Errorf("CreatePetRequest.tag.Description = %q, want %q", tagField.Description, "An optional tag for the pet")
+		}
 	}
 
 	// PetStatus enum values.

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -53,6 +53,7 @@ func (a *Analyzer) convertOperation(httpMethod, path string, pathItem *v3high.Pa
 
 	opDef := &ir.OperationDef{
 		Name:        name,
+		Summary:     op.Summary,
 		Description: op.Description,
 		HTTPMethod:  httpMethod,
 		Path:        path,
@@ -174,6 +175,7 @@ func (a *Analyzer) convertParam(param *v3high.Parameter) (*ir.ParamDef, error) {
 		Type:        goType,
 		Required:    required,
 		Description: param.Description,
+		Deprecated:  param.Deprecated,
 		Style:       param.Style,
 		Explode:     explode,
 	}, nil

--- a/internal/analyzer/operations_test.go
+++ b/internal/analyzer/operations_test.go
@@ -46,6 +46,12 @@ func TestAnalyzeOperations_Petstore(t *testing.T) {
 	if listPets.Path != "/pets" {
 		t.Errorf("ListPets.Path = %q, want /pets", listPets.Path)
 	}
+	if listPets.Summary != "List all pets" {
+		t.Errorf("ListPets.Summary = %q, want %q", listPets.Summary, "List all pets")
+	}
+	if listPets.Description != "Returns a paginated list of all pets in the store." {
+		t.Errorf("ListPets.Description = %q, want %q", listPets.Description, "Returns a paginated list of all pets in the store.")
+	}
 	if len(listPets.QueryParams) != 2 {
 		t.Errorf("ListPets: expected 2 query params, got %d", len(listPets.QueryParams))
 	} else {
@@ -57,6 +63,9 @@ func TestAnalyzeOperations_Petstore(t *testing.T) {
 		}
 		if listPets.QueryParams[0].Required {
 			t.Error("ListPets limit param should not be required")
+		}
+		if listPets.QueryParams[0].Description != "How many items to return at one time (max 100)" {
+			t.Errorf("ListPets limit param Description = %q, want %q", listPets.QueryParams[0].Description, "How many items to return at one time (max 100)")
 		}
 		if listPets.QueryParams[1].OrigName != "cursor" {
 			t.Errorf("ListPets.QueryParams[1].OrigName = %q, want cursor", listPets.QueryParams[1].OrigName)

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -152,12 +152,16 @@ func (a *Analyzer) convertAllOf(goName string, schema *highbase.Schema, nullable
 			}
 
 			td.Fields = append(td.Fields, &ir.Field{
-				Name:      naming.ToGoFieldName(propName),
-				JSONName:  propName,
-				Type:      goType,
-				Required:  required,
-				IsPointer: isPointer,
-				OmitEmpty: !required,
+				Name:        naming.ToGoFieldName(propName),
+				JSONName:    propName,
+				Type:        goType,
+				Description: propSchema.Description,
+				Required:    required,
+				IsPointer:   isPointer,
+				OmitEmpty:   !required,
+				Deprecated:  propSchema.Deprecated != nil && *propSchema.Deprecated,
+				ReadOnly:    propSchema.ReadOnly != nil && *propSchema.ReadOnly,
+				WriteOnly:   propSchema.WriteOnly != nil && *propSchema.WriteOnly,
 			})
 		}
 	}
@@ -279,14 +283,16 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 		}
 
 		td.Fields = append(td.Fields, &ir.Field{
-			Name:      naming.ToGoFieldName(propName),
-			JSONName:  propName,
-			Type:      goType,
-			Required:  required,
-			IsPointer: isPointer,
-			OmitEmpty: !required,
-			ReadOnly:  schema.ReadOnly != nil && *schema.ReadOnly,
-			WriteOnly: schema.WriteOnly != nil && *schema.WriteOnly,
+			Name:        naming.ToGoFieldName(propName),
+			JSONName:    propName,
+			Type:        goType,
+			Description: propSchema.Description,
+			Required:    required,
+			IsPointer:   isPointer,
+			OmitEmpty:   !required,
+			Deprecated:  propSchema.Deprecated != nil && *propSchema.Deprecated,
+			ReadOnly:    propSchema.ReadOnly != nil && *propSchema.ReadOnly,
+			WriteOnly:   propSchema.WriteOnly != nil && *propSchema.WriteOnly,
 		})
 	}
 

--- a/internal/generator/e2e_test.go
+++ b/internal/generator/e2e_test.go
@@ -112,6 +112,58 @@ func TestE2E_PetstoreGeneration(t *testing.T) {
 		t.Fatalf("go build failed: %v\n%s", err, string(output))
 	}
 	t.Log("generated code compiles successfully")
+
+	// Verify doc comments appear in generated output.
+	var typesContent, opsContent string
+	for _, f := range files {
+		switch f.Name {
+		case "types.go":
+			typesContent = string(f.Content)
+		case "operations.go":
+			opsContent = string(f.Content)
+		}
+	}
+
+	// Type-level doc comments.
+	if !strings.Contains(typesContent, "// Pet - A pet in the store") {
+		t.Error("types.go missing Pet type doc comment")
+	}
+	if !strings.Contains(typesContent, "// PetStatus - The current status of the pet in the store") {
+		t.Error("types.go missing PetStatus type doc comment")
+	}
+	if !strings.Contains(typesContent, "// Error - An error response from the API") {
+		t.Error("types.go missing Error type doc comment")
+	}
+
+	// Field-level doc comments.
+	if !strings.Contains(typesContent, "// The unique identifier for the pet") {
+		t.Error("types.go missing Pet.id field description")
+	}
+	if !strings.Contains(typesContent, "// The display name of the pet") {
+		t.Error("types.go missing Pet.name field description")
+	}
+	if !strings.Contains(typesContent, "// A human-readable error message") {
+		t.Error("types.go missing Error.message field description")
+	}
+
+	// Operation doc comments (summary + description).
+	if !strings.Contains(opsContent, "// ListPets - List all pets") {
+		t.Error("operations.go missing ListPets doc comment")
+	}
+	if !strings.Contains(opsContent, "// Returns a paginated list of all pets in the store.") {
+		t.Error("operations.go missing ListPets description in doc comment")
+	}
+	if !strings.Contains(opsContent, "// CreatePet - Create a pet") {
+		t.Error("operations.go missing CreatePet doc comment")
+	}
+
+	// Parameter descriptions in params struct.
+	if !strings.Contains(opsContent, "// How many items to return at one time (max 100)") {
+		t.Error("operations.go missing limit param description in ListPetsParams")
+	}
+	if !strings.Contains(opsContent, "// Pagination cursor") {
+		t.Error("operations.go missing cursor param description in ListPetsParams")
+	}
 }
 
 func TestE2E_TextPlainGeneration(t *testing.T) {

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -13,6 +13,11 @@ import (
 func FuncMap() template.FuncMap {
 	return template.FuncMap{
 		"cleanDoc":               cleanDoc,
+		"opDocComment":           opDocComment,
+		"typeDocComment":         typeDocComment,
+		"fieldDocComment":        fieldDocComment,
+		"paramDocComment":        paramDocComment,
+		"indent":                 indent,
 		"jsonTag":                jsonTag,
 		"enumLiteral":            enumLiteral,
 		"hasOperations":          hasOperations,
@@ -40,6 +45,132 @@ func cleanDoc(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
 	return strings.TrimSpace(s)
+}
+
+// commentLines splits a description into properly prefixed Go comment lines.
+// Each line gets a "// " prefix; blank lines produce "//".
+func commentLines(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			lines = append(lines, "//")
+		} else {
+			lines = append(lines, "// "+line)
+		}
+	}
+	return lines
+}
+
+// typeDocComment generates a Go doc comment for a type definition.
+// Format: "// TypeName - description" with multi-line support.
+func typeDocComment(td *ir.TypeDef) string {
+	desc := strings.TrimSpace(td.Description)
+	if desc == "" {
+		return ""
+	}
+	desc = strings.ReplaceAll(desc, "\r\n", "\n")
+	lines := strings.Split(desc, "\n")
+	var parts []string
+	parts = append(parts, "// "+td.Name+" - "+strings.TrimRight(lines[0], " \t"))
+	for _, line := range lines[1:] {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			parts = append(parts, "//")
+		} else {
+			parts = append(parts, "// "+line)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// opDocComment generates a complete Go doc comment for an operation method.
+// It combines Summary (first line), Description (body), and Deprecated marker.
+func opDocComment(op *ir.OperationDef) string {
+	summary := strings.TrimSpace(op.Summary)
+	desc := strings.TrimSpace(op.Description)
+
+	var parts []string
+
+	if summary != "" && desc != "" {
+		parts = append(parts, "// "+op.Name+" - "+summary)
+		parts = append(parts, "//")
+		parts = append(parts, commentLines(desc)...)
+	} else if summary != "" {
+		parts = append(parts, "// "+op.Name+" - "+summary)
+	} else if desc != "" {
+		descLines := commentLines(desc)
+		// Prefix the method name on the first line.
+		if len(descLines) > 0 {
+			descLines[0] = "// " + op.Name + " - " + strings.TrimPrefix(descLines[0], "// ")
+		}
+		parts = append(parts, descLines...)
+	}
+
+	if op.Deprecated {
+		if len(parts) > 0 {
+			parts = append(parts, "//")
+		}
+		parts = append(parts, "// Deprecated: this operation is deprecated.")
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n")
+}
+
+// fieldDocComment generates a Go doc comment for a struct field.
+// Includes description and a Deprecated marker if applicable.
+func fieldDocComment(f *ir.Field) string {
+	var parts []string
+	parts = append(parts, commentLines(f.Description)...)
+	if f.Deprecated {
+		if len(parts) > 0 {
+			parts = append(parts, "//")
+		}
+		parts = append(parts, "// Deprecated: this field is deprecated.")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n")
+}
+
+// paramDocComment generates a Go doc comment for a parameter struct field.
+// Includes description and a Deprecated marker if applicable.
+func paramDocComment(p *ir.ParamDef) string {
+	var parts []string
+	parts = append(parts, commentLines(p.Description)...)
+	if p.Deprecated {
+		if len(parts) > 0 {
+			parts = append(parts, "//")
+		}
+		parts = append(parts, "// Deprecated: this parameter is deprecated.")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n")
+}
+
+// indent prepends a tab character to each non-empty line of s.
+func indent(s string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = "\t" + line
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // jsonTag returns the JSON struct tag value for a field.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -39,9 +39,10 @@ func TestGenerate_StructAndEnum(t *testing.T) {
 				},
 			},
 			{
-				Name:       "PetStatus",
-				Kind:       ir.TypeKindEnum,
-				EnumGoType: "string",
+				Name:        "PetStatus",
+				Description: "The status of a pet",
+				Kind:        ir.TypeKindEnum,
+				EnumGoType:  "string",
 				EnumValues: []*ir.EnumVal{
 					{Name: "PetStatusAvailable", Value: "available"},
 					{Name: "PetStatusPending", Value: "pending"},
@@ -98,12 +99,17 @@ func TestGenerate_StructAndEnum(t *testing.T) {
 		t.Error("output missing json tag with omitempty for tag")
 	}
 
-	// Verify description comment
-	if !strings.Contains(content, "A pet in the store") {
-		t.Error("output missing Pet description comment")
+	// Verify type-level doc comment (new format: "// Name - description")
+	if !strings.Contains(content, "// Pet - A pet in the store") {
+		t.Error("output missing Pet type doc comment")
 	}
 	if !strings.Contains(content, "The name of the pet") {
 		t.Error("output missing Name field description comment")
+	}
+
+	// Verify enum type doc comment
+	if !strings.Contains(content, "// PetStatus - The status of a pet") {
+		t.Error("output missing PetStatus type doc comment")
 	}
 
 	// Verify enum type and consts
@@ -614,5 +620,372 @@ func TestEnumLiteral(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("enumLiteral(%v) = %q, want %q", tt.val.Value, got, tt.want)
 		}
+	}
+}
+
+func TestTypeDocComment(t *testing.T) {
+	tests := []struct {
+		name string
+		td   *ir.TypeDef
+		want string
+	}{
+		{
+			name: "empty description",
+			td:   &ir.TypeDef{Name: "Pet", Description: ""},
+			want: "",
+		},
+		{
+			name: "single line",
+			td:   &ir.TypeDef{Name: "Pet", Description: "A pet in the store"},
+			want: "// Pet - A pet in the store",
+		},
+		{
+			name: "multi line",
+			td:   &ir.TypeDef{Name: "Pet", Description: "A pet in the store\nWith extra info"},
+			want: "// Pet - A pet in the store\n// With extra info",
+		},
+		{
+			name: "whitespace only",
+			td:   &ir.TypeDef{Name: "Pet", Description: "  "},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := typeDocComment(tt.td)
+			if got != tt.want {
+				t.Errorf("typeDocComment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpDocComment(t *testing.T) {
+	tests := []struct {
+		name string
+		op   *ir.OperationDef
+		want string
+	}{
+		{
+			name: "empty",
+			op:   &ir.OperationDef{Name: "ListPets"},
+			want: "",
+		},
+		{
+			name: "summary only",
+			op:   &ir.OperationDef{Name: "ListPets", Summary: "List all pets"},
+			want: "// ListPets - List all pets",
+		},
+		{
+			name: "description only",
+			op:   &ir.OperationDef{Name: "ListPets", Description: "Returns all pets"},
+			want: "// ListPets - Returns all pets",
+		},
+		{
+			name: "summary and description",
+			op:   &ir.OperationDef{Name: "ListPets", Summary: "List all pets", Description: "Returns a paginated list of all pets."},
+			want: "// ListPets - List all pets\n//\n// Returns a paginated list of all pets.",
+		},
+		{
+			name: "deprecated only",
+			op:   &ir.OperationDef{Name: "ListPets", Deprecated: true},
+			want: "// Deprecated: this operation is deprecated.",
+		},
+		{
+			name: "summary and deprecated",
+			op:   &ir.OperationDef{Name: "ListPets", Summary: "List all pets", Deprecated: true},
+			want: "// ListPets - List all pets\n//\n// Deprecated: this operation is deprecated.",
+		},
+		{
+			name: "multi-line description",
+			op:   &ir.OperationDef{Name: "ListPets", Description: "Returns pets.\nSupports pagination."},
+			want: "// ListPets - Returns pets.\n// Supports pagination.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := opDocComment(tt.op)
+			if got != tt.want {
+				t.Errorf("opDocComment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFieldDocComment(t *testing.T) {
+	tests := []struct {
+		name  string
+		field *ir.Field
+		want  string
+	}{
+		{
+			name:  "empty",
+			field: &ir.Field{Name: "ID"},
+			want:  "",
+		},
+		{
+			name:  "description only",
+			field: &ir.Field{Name: "ID", Description: "The unique ID"},
+			want:  "// The unique ID",
+		},
+		{
+			name:  "deprecated only",
+			field: &ir.Field{Name: "ID", Deprecated: true},
+			want:  "// Deprecated: this field is deprecated.",
+		},
+		{
+			name:  "description and deprecated",
+			field: &ir.Field{Name: "ID", Description: "The unique ID", Deprecated: true},
+			want:  "// The unique ID\n//\n// Deprecated: this field is deprecated.",
+		},
+		{
+			name:  "multi-line description",
+			field: &ir.Field{Name: "ID", Description: "The unique ID.\nMust be positive."},
+			want:  "// The unique ID.\n// Must be positive.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fieldDocComment(tt.field)
+			if got != tt.want {
+				t.Errorf("fieldDocComment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParamDocComment(t *testing.T) {
+	tests := []struct {
+		name  string
+		param *ir.ParamDef
+		want  string
+	}{
+		{
+			name:  "empty",
+			param: &ir.ParamDef{Name: "limit"},
+			want:  "",
+		},
+		{
+			name:  "description only",
+			param: &ir.ParamDef{Name: "limit", Description: "Max items to return"},
+			want:  "// Max items to return",
+		},
+		{
+			name:  "deprecated only",
+			param: &ir.ParamDef{Name: "limit", Deprecated: true},
+			want:  "// Deprecated: this parameter is deprecated.",
+		},
+		{
+			name:  "description and deprecated",
+			param: &ir.ParamDef{Name: "limit", Description: "Max items to return", Deprecated: true},
+			want:  "// Max items to return\n//\n// Deprecated: this parameter is deprecated.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paramDocComment(tt.param)
+			if got != tt.want {
+				t.Errorf("paramDocComment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"single line", "// hello", "\t// hello"},
+		{"multi line", "// line1\n// line2", "\t// line1\n\t// line2"},
+		{"with blank line", "// line1\n//\n// line2", "\t// line1\n\t//\n\t// line2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := indent(tt.input)
+			if got != tt.want {
+				t.Errorf("indent(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerate_DeprecatedOperation(t *testing.T) {
+	pkg := &ir.Package{
+		Name: "testpkg",
+		Types: []*ir.TypeDef{
+			{Name: "Simple", Kind: ir.TypeKindStruct, Fields: []*ir.Field{
+				{Name: "Value", JSONName: "value", Type: "string", Required: true},
+			}},
+		},
+		Operations: []*ir.OperationDef{
+			{
+				Name:        "OldMethod",
+				Summary:     "An old method",
+				HTTPMethod:  "GET",
+				Path:        "/old",
+				Deprecated:  true,
+				SuccessResponse: &ir.ResponseDef{
+					StatusCode:  "200",
+					ContentType: "application/json",
+					TypeName:    "Simple",
+				},
+			},
+		},
+	}
+
+	gen, err := New(pkg)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	var opsContent string
+	for _, f := range files {
+		if f.Name == "operations.go" {
+			opsContent = string(f.Content)
+			break
+		}
+	}
+	if opsContent == "" {
+		t.Fatal("expected operations.go in generated files")
+	}
+
+	if !strings.Contains(opsContent, "// Deprecated: this operation is deprecated.") {
+		t.Error("output missing Deprecated marker in operation doc comment")
+	}
+	if !strings.Contains(opsContent, "// OldMethod - An old method") {
+		t.Error("output missing operation summary in doc comment")
+	}
+}
+
+func TestGenerate_FieldDeprecated(t *testing.T) {
+	pkg := &ir.Package{
+		Name: "testpkg",
+		Types: []*ir.TypeDef{
+			{
+				Name: "Item",
+				Kind: ir.TypeKindStruct,
+				Fields: []*ir.Field{
+					{
+						Name:        "OldField",
+						JSONName:    "oldField",
+						Type:        "string",
+						Description: "This field is old",
+						Deprecated:  true,
+						Required:    true,
+					},
+					{
+						Name:     "NewField",
+						JSONName: "newField",
+						Type:     "string",
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+
+	gen, err := New(pkg)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	var content string
+	for _, f := range files {
+		if f.Name == "types.go" {
+			content = string(f.Content)
+			break
+		}
+	}
+	if content == "" {
+		t.Fatal("expected types.go in generated files")
+	}
+
+	if !strings.Contains(content, "// Deprecated: this field is deprecated.") {
+		t.Error("output missing Deprecated marker for OldField")
+	}
+	if !strings.Contains(content, "// This field is old") {
+		t.Error("output missing description for deprecated field")
+	}
+}
+
+func TestGenerate_ParamDescriptions(t *testing.T) {
+	pkg := &ir.Package{
+		Name: "testpkg",
+		Types: []*ir.TypeDef{
+			{Name: "Result", Kind: ir.TypeKindStruct, Fields: []*ir.Field{
+				{Name: "Data", JSONName: "data", Type: "string", Required: true},
+			}},
+		},
+		Operations: []*ir.OperationDef{
+			{
+				Name:       "Search",
+				Summary:    "Search items",
+				HTTPMethod: "GET",
+				Path:       "/search",
+				QueryParams: []*ir.ParamDef{
+					{
+						Name:        "query",
+						FieldName:   "Query",
+						OrigName:    "query",
+						Location:    "query",
+						Type:        "string",
+						Required:    false,
+						Description: "The search query string",
+					},
+					{
+						Name:        "limit",
+						FieldName:   "Limit",
+						OrigName:    "limit",
+						Location:    "query",
+						Type:        "int32",
+						Required:    false,
+						Description: "Maximum number of results",
+					},
+				},
+				SuccessResponse: &ir.ResponseDef{
+					StatusCode:  "200",
+					ContentType: "application/json",
+					TypeName:    "Result",
+				},
+			},
+		},
+	}
+
+	gen, err := New(pkg)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	var opsContent string
+	for _, f := range files {
+		if f.Name == "operations.go" {
+			opsContent = string(f.Content)
+			break
+		}
+	}
+	if opsContent == "" {
+		t.Fatal("expected operations.go in generated files")
+	}
+
+	if !strings.Contains(opsContent, "// The search query string") {
+		t.Error("output missing query param description")
+	}
+	if !strings.Contains(opsContent, "// Maximum number of results") {
+		t.Error("output missing limit param description")
 	}
 }

--- a/internal/ir/operations.go
+++ b/internal/ir/operations.go
@@ -3,6 +3,7 @@ package ir
 // OperationDef represents a single API operation.
 type OperationDef struct {
 	Name            string          // Go method name (e.g., "ListUsers")
+	Summary         string          // Short summary from the spec
 	Description     string
 	HTTPMethod      string          // "GET", "POST", etc.
 	Path            string          // URL path template (e.g., "/users/{id}")
@@ -29,6 +30,7 @@ type ParamDef struct {
 	Type        string // Go type expression
 	Required    bool
 	Description string
+	Deprecated  bool
 	Style       string // serialization style
 	Explode     bool
 }

--- a/internal/templates/operations.go.tmpl
+++ b/internal/templates/operations.go.tmpl
@@ -11,13 +11,16 @@ import (
 {{ range .Operations }}
 {{ if hasOptionalParams . }}// {{ .Name }}Params contains optional parameters for the {{ .Name }} operation.
 type {{ .Name }}Params struct {
-{{ range .QueryParams }}{{ if not .Required }}	{{ .FieldName }} {{ paramType . }} `json:"{{ .OrigName }},omitempty"`
-{{ end }}{{ end }}{{ range .HeaderParams }}{{ if not .Required }}	{{ .FieldName }} {{ paramType . }} `json:"{{ .OrigName }},omitempty"`
-{{ end }}{{ end }}{{ range .CookieParams }}{{ if not .Required }}	{{ .FieldName }} {{ paramType . }} `json:"{{ .OrigName }},omitempty"`
+{{ range .QueryParams }}{{ if not .Required }}{{ $pDoc := paramDocComment . }}{{ if $pDoc }}{{ indent $pDoc }}
+{{ end }}	{{ .FieldName }} {{ paramType . }} `json:"{{ .OrigName }},omitempty"`
+{{ end }}{{ end }}{{ range .HeaderParams }}{{ if not .Required }}{{ $pDoc := paramDocComment . }}{{ if $pDoc }}{{ indent $pDoc }}
+{{ end }}	{{ .FieldName }} {{ paramType . }} `json:"{{ .OrigName }},omitempty"`
+{{ end }}{{ end }}{{ range .CookieParams }}{{ if not .Required }}{{ $pDoc := paramDocComment . }}{{ if $pDoc }}{{ indent $pDoc }}
+{{ end }}	{{ .FieldName }} {{ paramType . }} `json:"{{ .OrigName }},omitempty"`
 {{ end }}{{ end }}}
 {{ end }}
-{{ if .Description }}// {{ .Name }} - {{ cleanDoc .Description }}{{ end }}
-func (c *Client) {{ .Name }}(ctx context.Context{{ range .PathParams }}, {{ .Name }} {{ .Type }}{{ end }}{{ if hasBody . }}, body {{ if .RequestBody }}{{ if not .RequestBody.Required }}*{{ end }}{{ .RequestBody.TypeName }}{{ else }}any{{ end }}{{ end }}{{ if hasOptionalParams . }}, opts ...{{ .Name }}Params{{ end }}) {{ if successType . }}(*{{ successType . }}, error){{ else }}error{{ end }} {
+{{ $opDoc := opDocComment . }}{{ if $opDoc }}{{ $opDoc }}
+{{ end }}func (c *Client) {{ .Name }}(ctx context.Context{{ range .PathParams }}, {{ .Name }} {{ .Type }}{{ end }}{{ if hasBody . }}, body {{ if .RequestBody }}{{ if not .RequestBody.Required }}*{{ end }}{{ .RequestBody.TypeName }}{{ else }}any{{ end }}{{ end }}{{ if hasOptionalParams . }}, opts ...{{ .Name }}Params{{ end }}) {{ if successType . }}(*{{ successType . }}, error){{ else }}error{{ end }} {
 	path := "{{ .Path }}"
 {{ range .PathParams }}	path = pathReplace(path, "{{ .OrigName }}", {{ .Name }})
 {{ end }}

--- a/internal/templates/types.go.tmpl
+++ b/internal/templates/types.go.tmpl
@@ -11,19 +11,22 @@ import (
 )
 
 {{ range .Types }}
-{{ if .Description }}// {{ .Name }} - {{ cleanDoc .Description }}{{ end }}
-{{ if eq .Kind 0 }}type {{ .Name }} struct {
-{{ range .Fields }}{{ if .Description }}	// {{ cleanDoc .Description }}
+{{ $typeDoc := typeDocComment . }}{{ if eq .Kind 0 }}{{ if $typeDoc }}{{ $typeDoc }}
+{{ end }}type {{ .Name }} struct {
+{{ range .Fields }}{{ $fDoc := fieldDocComment . }}{{ if $fDoc }}{{ indent $fDoc }}
 {{ end }}{{ if .Embedded }}	{{ .Type }}
 {{ else }}	{{ .Name }} {{ .Type }} `json:"{{ jsonTag . }}"`
 {{ end }}{{ end }}}
-{{ else if eq .Kind 1 }}type {{ .Name }} = {{ .GoType }}
-{{ else if eq .Kind 2 }}{{ $typeName := .Name }}type {{ .Name }} {{ .EnumGoType }}
+{{ else if eq .Kind 1 }}{{ if $typeDoc }}{{ $typeDoc }}
+{{ end }}type {{ .Name }} = {{ .GoType }}
+{{ else if eq .Kind 2 }}{{ $typeName := .Name }}{{ if $typeDoc }}{{ $typeDoc }}
+{{ end }}type {{ .Name }} {{ .EnumGoType }}
 
 const (
 {{ range .EnumValues }}	{{ .Name }} {{ $typeName }} = {{ enumLiteral . }}
 {{ end }})
-{{ else if eq .Kind 3 }}{{ $typeName := .Name }}// {{ .Name }} represents a union type (oneOf/anyOf).
+{{ else if eq .Kind 3 }}{{ $typeName := .Name }}{{ if $typeDoc }}{{ $typeDoc }}
+{{ else }}// {{ .Name }} represents a union type (oneOf/anyOf).{{ end }}
 // Variants: {{ range $i, $v := .UnionTypes }}{{ if $i }}, {{ end }}{{ $v.TypeName }}{{ end }}
 type {{ .Name }} struct {
 	Value any

--- a/testdata/petstore.yaml
+++ b/testdata/petstore.yaml
@@ -10,6 +10,7 @@ paths:
     get:
       operationId: listPets
       summary: List all pets
+      description: Returns a paginated list of all pets in the store.
       parameters:
         - name: limit
           in: query
@@ -110,6 +111,7 @@ components:
   schemas:
     Pet:
       type: object
+      description: A pet in the store
       required:
         - id
         - name
@@ -117,47 +119,59 @@ components:
         id:
           type: integer
           format: int64
+          description: The unique identifier for the pet
         name:
           type: string
+          description: The display name of the pet
         tag:
           type:
             - string
             - "null"
+          description: An optional tag for categorization
         status:
           $ref: "#/components/schemas/PetStatus"
         createdAt:
           type: string
           format: date-time
+          description: When the pet was created
     PetStatus:
       type: string
+      description: The current status of the pet in the store
       enum:
         - available
         - pending
         - sold
     PetList:
       type: object
+      description: A paginated list of pets
       required:
         - items
       properties:
         items:
           type: array
+          description: The list of pets
           items:
             $ref: "#/components/schemas/Pet"
         nextCursor:
           type:
             - string
             - "null"
+          description: Cursor for the next page of results
     CreatePetRequest:
       type: object
+      description: Request body for creating a new pet
       required:
         - name
       properties:
         name:
           type: string
+          description: The name of the pet to create
         tag:
           type: string
+          description: An optional tag for the pet
     Error:
       type: object
+      description: An error response from the API
       required:
         - code
         - message
@@ -165,8 +179,10 @@ components:
         code:
           type: integer
           format: int32
+          description: The error code
         message:
           type: string
+          description: A human-readable error message
   securitySchemes:
     bearerAuth:
       type: http


### PR DESCRIPTION
The analyzer was dropping most documentation from OpenAPI specs. Field descriptions were never extracted from property schemas, readOnly/writeOnly were reading from the wrong schema, and deprecation flags were ignored. Operation summaries weren't captured either.

This fixes all of that and updates the templates to actually render the docs as proper Go comments. Types, fields, operations, and params structs all get doc comments now. Deprecated items get a `// Deprecated:` marker.
