### PR TITLE
feat: typed discriminated unions for inline oneOf/anyOf schemas

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -15,14 +15,19 @@ type Analyzer struct {
 	namer *naming.Namer
 	// typesBySchema tracks already-converted schema names to avoid duplicates.
 	typesBySchema map[string]*ir.TypeDef
+	// synthesized holds union types created for inline oneOf/anyOf schemas,
+	// deduplicated on their variant set and discriminator.
+	synthesized      []*ir.TypeDef
+	synthesizedByKey map[string]*ir.TypeDef
 }
 
 // New creates an Analyzer for the given high-level OpenAPI model.
 func New(model *v3high.Document) *Analyzer {
 	return &Analyzer{
-		model:         model,
-		namer:         naming.NewNamer(),
-		typesBySchema: make(map[string]*ir.TypeDef),
+		model:            model,
+		namer:            naming.NewNamer(),
+		typesBySchema:    make(map[string]*ir.TypeDef),
+		synthesizedByKey: make(map[string]*ir.TypeDef),
 	}
 }
 
@@ -62,6 +67,9 @@ func (a *Analyzer) Analyze(packageName string) (*ir.Package, error) {
 	if err := a.analyzeSecuritySchemes(pkg); err != nil {
 		return nil, err
 	}
+
+	// Append union types synthesized for inline oneOf/anyOf schemas.
+	pkg.Types = append(pkg.Types, a.synthesized...)
 
 	// Detect paginated operations.
 	a.detectPagination(pkg)

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -788,6 +788,7 @@ func TestComplexSchemas_AllTypesPresent(t *testing.T) {
 		"Animal", "Dog", "Circle", "Rectangle", "Shape",
 		"StringOrInt", "Metadata", "Labels", "Config",
 		"DogOrCircle", "Timestamped", "TimestampedDog",
+		"ShapeCollection", "ShapeCollectionShapesValue",
 	}
 
 	if len(pkg.Types) != len(expectedTypes) {

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -160,7 +160,7 @@ func (a *Analyzer) convertParam(param *v3high.Parameter) (*ir.ParamDef, error) {
 			return nil, fmt.Errorf("building param schema: %w", err)
 		}
 		if schema != nil {
-			goType = a.resolveGoType(schema)
+			goType = a.resolveGoType(schema, "")
 		}
 	}
 
@@ -299,7 +299,7 @@ func (a *Analyzer) resolveMediaTypeSchema(mt *v3high.MediaType) string {
 	if err != nil || schema == nil {
 		return ""
 	}
-	return a.resolveGoType(schema)
+	return a.resolveGoType(schema, "")
 }
 
 // convertSecurityReqs converts OpenAPI security requirements to IR.

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	highbase "github.com/pb33f/libopenapi/datamodel/high/base"
 
@@ -144,7 +145,7 @@ func (a *Analyzer) convertAllOf(goName string, schema *highbase.Schema, nullable
 
 			required := requiredSet[propName]
 			propNullable := isNullable(propSchema)
-			goType := a.resolveGoType(propSchema)
+			goType := a.resolveGoType(propSchema, goName+naming.ToGoFieldName(propName))
 			isPointer := !required || propNullable
 
 			if isPointer && goType != "any" && !isSliceType(goType) && !isMapType(goType) {
@@ -275,7 +276,7 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 
 		required := requiredSet[propName]
 		propNullable := isNullable(propSchema)
-		goType := a.resolveGoType(propSchema)
+		goType := a.resolveGoType(propSchema, goName+naming.ToGoFieldName(propName))
 		isPointer := !required || propNullable
 
 		if isPointer && goType != "any" && !isSliceType(goType) && !isMapType(goType) {
@@ -298,7 +299,7 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 
 	// If the object has both properties and additionalProperties, add an extra field.
 	if schema.AdditionalProperties != nil {
-		mapValueType := a.resolveAdditionalPropertiesType(schema)
+		mapValueType := a.resolveAdditionalPropertiesType(schema, goName)
 		td.Fields = append(td.Fields, &ir.Field{
 			Name:      "AdditionalProperties",
 			JSONName:  "-",
@@ -313,7 +314,7 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 // convertAdditionalPropertiesMap creates a map alias when an object has
 // additionalProperties but no defined properties.
 func (a *Analyzer) convertAdditionalPropertiesMap(goName string, schema *highbase.Schema, nullable bool) (*ir.TypeDef, error) {
-	mapValueType := a.resolveAdditionalPropertiesType(schema)
+	mapValueType := a.resolveAdditionalPropertiesType(schema, goName)
 	return &ir.TypeDef{
 		Name:        goName,
 		Description: schema.Description,
@@ -324,7 +325,7 @@ func (a *Analyzer) convertAdditionalPropertiesMap(goName string, schema *highbas
 }
 
 // resolveAdditionalPropertiesType returns the Go value type for additionalProperties.
-func (a *Analyzer) resolveAdditionalPropertiesType(schema *highbase.Schema) string {
+func (a *Analyzer) resolveAdditionalPropertiesType(schema *highbase.Schema, nameHint string) string {
 	ap := schema.AdditionalProperties
 	if ap == nil {
 		return "any"
@@ -337,7 +338,7 @@ func (a *Analyzer) resolveAdditionalPropertiesType(schema *highbase.Schema) stri
 	if ap.IsA() && ap.A != nil {
 		apSchema, err := ap.A.BuildSchema()
 		if err == nil && apSchema != nil {
-			return a.resolveGoType(apSchema)
+			return a.resolveGoType(apSchema, suffixHint(nameHint, "Value"))
 		}
 	}
 	return "any"
@@ -352,7 +353,7 @@ func (a *Analyzer) convertArray(goName string, schema *highbase.Schema, nullable
 			return nil, fmt.Errorf("building array items schema: %w", err)
 		}
 		if itemSchema != nil {
-			elemType = a.resolveGoType(itemSchema)
+			elemType = a.resolveGoType(itemSchema, suffixHint(goName, "Item"))
 		}
 	}
 
@@ -379,8 +380,10 @@ func (a *Analyzer) convertPrimitive(goName, primaryType string, schema *highbase
 }
 
 // resolveGoType determines the Go type expression for a schema, handling refs
-// to known types, arrays, and primitives.
-func (a *Analyzer) resolveGoType(schema *highbase.Schema) string {
+// to known types, arrays, primitives, and inline unions. nameHint carries the
+// naming context (parent type + field) used when a type must be synthesized;
+// pass "" when no context is available.
+func (a *Analyzer) resolveGoType(schema *highbase.Schema, nameHint string) string {
 	// Check if this schema is a $ref pointing to a known component schema.
 	if schema.ParentProxy != nil {
 		ref := schema.ParentProxy.GetReference()
@@ -396,13 +399,21 @@ func (a *Analyzer) resolveGoType(schema *highbase.Schema) string {
 		}
 	}
 
+	// Inline oneOf/anyOf: synthesize a named union so $ref variants stay typed.
+	if name, ok := a.synthesizeInlineUnion(schema, nameHint); ok {
+		return name
+	}
+
 	// Enum type referenced inline -- use the primary type.
 	primaryType := primaryType(schema)
 
 	switch primaryType {
 	case "object":
-		// Inline objects without properties -> map[string]any.
+		// Inline objects without properties -> a map of the additionalProperties type.
 		if schema.Properties == nil || schema.Properties.Len() == 0 {
+			if schema.AdditionalProperties != nil {
+				return "map[string]" + a.resolveAdditionalPropertiesType(schema, nameHint)
+			}
 			return "map[string]any"
 		}
 		// Complex inline object -- for now use any. Full support would create
@@ -413,7 +424,7 @@ func (a *Analyzer) resolveGoType(schema *highbase.Schema) string {
 		if schema.Items != nil && schema.Items.IsA() {
 			itemSchema, _ := schema.Items.A.BuildSchema()
 			if itemSchema != nil {
-				elemType = a.resolveGoType(itemSchema)
+				elemType = a.resolveGoType(itemSchema, suffixHint(nameHint, "Item"))
 			}
 		}
 		return "[]" + elemType
@@ -422,6 +433,63 @@ func (a *Analyzer) resolveGoType(schema *highbase.Schema) string {
 	default:
 		return "any"
 	}
+}
+
+// synthesizeInlineUnion creates a named union TypeDef for an inline
+// oneOf/anyOf schema so its $ref variants keep their generated types instead
+// of degrading to any. Identical unions (same variants and discriminator) are
+// synthesized once and reuse the first occurrence's name; the resulting types
+// are emitted after the component schemas. Returns false when the schema is
+// not a union, has no $ref variants worth naming, or no nameHint is available.
+func (a *Analyzer) synthesizeInlineUnion(schema *highbase.Schema, nameHint string) (string, bool) {
+	variants := schema.OneOf
+	kind := "oneOf"
+	if len(variants) == 0 {
+		variants = schema.AnyOf
+		kind = "anyOf"
+	}
+	if len(variants) == 0 || nameHint == "" {
+		return "", false
+	}
+
+	refs := make([]string, 0, len(variants))
+	hasRef := false
+	for _, proxy := range variants {
+		ref := proxy.GetReference()
+		if ref != "" {
+			hasRef = true
+		}
+		refs = append(refs, ref)
+	}
+	if !hasRef {
+		return "", false
+	}
+
+	key := kind + "|" + strings.Join(refs, ",")
+	if schema.Discriminator != nil {
+		key += "|" + schema.Discriminator.PropertyName
+	}
+	if existing, ok := a.synthesizedByKey[key]; ok {
+		return existing.Name, true
+	}
+
+	goName := a.namer.RegisterName(naming.ToGoName(nameHint))
+	td, err := a.convertUnion(goName, schema, variants, isNullable(schema))
+	if err != nil {
+		return "", false
+	}
+	a.synthesizedByKey[key] = td
+	a.synthesized = append(a.synthesized, td)
+	return goName, true
+}
+
+// suffixHint appends a suffix to a naming hint, preserving emptiness so that
+// hintless contexts stay hintless.
+func suffixHint(nameHint, suffix string) string {
+	if nameHint == "" {
+		return ""
+	}
+	return nameHint + suffix
 }
 
 // primaryType extracts the primary (non-null) type from the schema's Type array.

--- a/internal/analyzer/schemas_inline_union_test.go
+++ b/internal/analyzer/schemas_inline_union_test.go
@@ -1,0 +1,57 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/parallelworks/openapi-client-generator/internal/ir"
+)
+
+func TestInlineOneOf_AdditionalPropertiesSynthesizesUnion(t *testing.T) {
+	_, typeMap := parseComplexSchemas(t)
+
+	sc := typeMap["ShapeCollection"]
+	if sc == nil {
+		t.Fatal("ShapeCollection type not found")
+	}
+	fields := make(map[string]*ir.Field)
+	for _, f := range sc.Fields {
+		fields[f.JSONName] = f
+	}
+
+	shapes := fields["shapes"]
+	if shapes == nil {
+		t.Fatal("ShapeCollection: missing shapes field")
+	}
+	if shapes.Type != "map[string]ShapeCollectionShapesValue" {
+		t.Errorf("shapes type = %q, want map[string]ShapeCollectionShapesValue", shapes.Type)
+	}
+
+	// An identical inline union elsewhere reuses the synthesized type.
+	backup := fields["backupShapes"]
+	if backup == nil {
+		t.Fatal("ShapeCollection: missing backupShapes field")
+	}
+	if backup.Type != "map[string]ShapeCollectionShapesValue" {
+		t.Errorf("backupShapes type = %q, want the deduplicated map[string]ShapeCollectionShapesValue", backup.Type)
+	}
+
+	union := typeMap["ShapeCollectionShapesValue"]
+	if union == nil {
+		t.Fatal("synthesized union ShapeCollectionShapesValue not found in package types")
+	}
+	if union.Kind != ir.TypeKindUnion {
+		t.Errorf("union kind = %v, want union", union.Kind)
+	}
+	if len(union.UnionTypes) != 2 {
+		t.Fatalf("union variants = %d, want 2", len(union.UnionTypes))
+	}
+	if union.Discriminator == nil {
+		t.Fatal("synthesized union has no discriminator")
+	}
+	if union.Discriminator.PropertyName != "shapeType" {
+		t.Errorf("discriminator property = %q, want shapeType", union.Discriminator.PropertyName)
+	}
+	if union.Discriminator.Mapping["circle"] != "Circle" || union.Discriminator.Mapping["rectangle"] != "Rectangle" {
+		t.Errorf("discriminator mapping = %v, want circle->Circle, rectangle->Rectangle", union.Discriminator.Mapping)
+	}
+}

--- a/internal/generator/e2e_inline_union_test.go
+++ b/internal/generator/e2e_inline_union_test.go
@@ -1,0 +1,113 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/parallelworks/openapi-client-generator/internal/analyzer"
+	"github.com/parallelworks/openapi-client-generator/internal/parser"
+)
+
+// TestE2E_InlineUnionRuntimeDispatch generates a client from a spec whose map
+// values are an inline discriminated oneOf, then compiles and RUNS a test
+// against the generated code to prove UnmarshalJSON dispatches the
+// discriminator to the right variant type at runtime.
+func TestE2E_InlineUnionRuntimeDispatch(t *testing.T) {
+	specPath := filepath.Join(projectRoot(), "testdata", "complex-schemas.yaml")
+
+	result, err := parser.Parse(specPath, parser.Config{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	a := analyzer.New(result.Model)
+	pkg, err := a.Analyze("complexschemas")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	gen, err := New(pkg)
+	if err != nil {
+		t.Fatalf("New generator: %v", err)
+	}
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	goMod := []byte("module complex-e2e-test\n\ngo 1.25.5\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), goMod, 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+	if err := WriteFiles(tmpDir, files); err != nil {
+		t.Fatalf("WriteFiles: %v", err)
+	}
+
+	runtimeTest := []byte(`package complexschemas
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUnionValueTypeSwitch(t *testing.T) {
+	payload := []byte(` + "`" + `{
+		"shapes": {
+			"a": {"shapeType": "circle", "radius": 2.5},
+			"b": {"shapeType": "rectangle", "width": 3, "height": 4}
+		}
+	}` + "`" + `)
+
+	var sc ShapeCollection
+	if err := json.Unmarshal(payload, &sc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	switch v := sc.Shapes["a"].Value.(type) {
+	case Circle:
+		if v.Radius != 2.5 {
+			t.Errorf("circle radius = %v, want 2.5", v.Radius)
+		}
+	default:
+		t.Fatalf("shapes[a].Value = %T, want Circle", sc.Shapes["a"].Value)
+	}
+
+	switch v := sc.Shapes["b"].Value.(type) {
+	case Rectangle:
+		if v.Width != 3 || v.Height != 4 {
+			t.Errorf("rectangle = %+v, want width 3 height 4", v)
+		}
+	default:
+		t.Fatalf("shapes[b].Value = %T, want Rectangle", sc.Shapes["b"].Value)
+	}
+
+	out, err := json.Marshal(sc.Shapes["a"])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), ` + "`" + `"shapeType":"circle"` + "`" + `) {
+		t.Errorf("marshal lost the discriminator: %s", out)
+	}
+
+	var bad ShapeCollectionShapesValue
+	if err := json.Unmarshal([]byte(` + "`" + `{"shapeType":"hexagon"}` + "`" + `), &bad); err == nil {
+		t.Fatal("expected an error for an unknown shapeType, got nil")
+	}
+}
+`)
+	if err := os.WriteFile(filepath.Join(tmpDir, "union_runtime_test.go"), runtimeTest, 0o644); err != nil {
+		t.Fatalf("writing runtime test: %v", err)
+	}
+
+	cmd := exec.Command("go", "test", "./...")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go test on generated code failed: %v\n%s", err, string(output))
+	}
+	t.Logf("runtime dispatch test passed:\n%s", string(output))
+}

--- a/testdata/complex-schemas.yaml
+++ b/testdata/complex-schemas.yaml
@@ -134,3 +134,32 @@ components:
           properties:
             registrationId:
               type: string
+
+    # --- inline discriminated oneOf under additionalProperties ---
+    ShapeCollection:
+      type: object
+      required:
+        - shapes
+      properties:
+        shapes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - $ref: "#/components/schemas/Circle"
+              - $ref: "#/components/schemas/Rectangle"
+            discriminator:
+              propertyName: shapeType
+              mapping:
+                circle: "#/components/schemas/Circle"
+                rectangle: "#/components/schemas/Rectangle"
+        backupShapes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - $ref: "#/components/schemas/Circle"
+              - $ref: "#/components/schemas/Rectangle"
+            discriminator:
+              propertyName: shapeType
+              mapping:
+                circle: "#/components/schemas/Circle"
+                rectangle: "#/components/schemas/Rectangle"


### PR DESCRIPTION
## What does this PR do?

Inline `oneOf`/`anyOf` schemas (in property position or under `additionalProperties`) previously degraded to `any` / `map[string]any`. The analyzer now synthesizes a named union type for them, so they flow through the existing union template, which already generates a `Value any` wrapper with discriminator-dispatching `UnmarshalJSON`.

## Why is this PR needed?

Better support for `oneOf` and discriminator keys.