### PR TITLE
fix: retries can duplicate non-idempotent requests on 5xx

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1046,4 +1046,16 @@ func TestGenerate_RetriesTransientNetworkErrors(t *testing.T) {
 	if strings.Contains(clientContent, "// Network errors are not retryable.") {
 		t.Error("client.go still treats all network errors as non-retryable")
 	}
+
+	// Status-code retries must be gated by method so non-idempotent requests
+	// (POST/PATCH) aren't replayed on 5xx.
+	if !strings.Contains(retryContent, "func shouldRetryStatus(method string, statusCode int, cfg RetryConfig) bool") {
+		t.Error("retry.go missing shouldRetryStatus helper")
+	}
+	if !strings.Contains(clientContent, "shouldRetryStatus(method, resp.StatusCode, *c.retryConfig)") {
+		t.Error("client.go status-retry not gated by method")
+	}
+	if strings.Contains(clientContent, "shouldRetry(resp.StatusCode, *c.retryConfig)") {
+		t.Error("client.go still retries all methods on retryable status codes")
+	}
 }

--- a/internal/templates/client.go.tmpl
+++ b/internal/templates/client.go.tmpl
@@ -112,6 +112,10 @@ func (c *Client) do(ctx context.Context, method string, path string, body any, r
 {{ end }}
 		resp, err := transport(req)
 		if err != nil {
+			// A middleware may return a response alongside the error; don't leak its body.
+			if resp != nil {
+				resp.Body.Close()
+			}
 			// Retry idempotent requests on transient network errors.
 			if c.retryConfig != nil && attempt < maxAttempts-1 && isIdempotentMethod(method) && isRetryableNetworkError(err) {
 				timer := time.NewTimer(retryDelay(attempt, *c.retryConfig, nil))
@@ -133,7 +137,7 @@ func (c *Client) do(ctx context.Context, method string, path string, body any, r
 		}
 
 		// Check if we should retry.
-		if c.retryConfig != nil && attempt < maxAttempts-1 && shouldRetry(resp.StatusCode, *c.retryConfig) {
+		if c.retryConfig != nil && attempt < maxAttempts-1 && shouldRetryStatus(method, resp.StatusCode, *c.retryConfig) {
 			delay := retryDelay(attempt, *c.retryConfig, resp)
 			timer := time.NewTimer(delay)
 			select {

--- a/internal/templates/retry.go.tmpl
+++ b/internal/templates/retry.go.tmpl
@@ -64,6 +64,15 @@ func shouldRetry(statusCode int, cfg RetryConfig) bool {
 	return false
 }
 
+// shouldRetryStatus reports whether a response with statusCode should be retried for method.
+func shouldRetryStatus(method string, statusCode int, cfg RetryConfig) bool {
+	if !shouldRetry(statusCode, cfg) {
+		return false
+	}
+	// Non-idempotent methods are only safe to retry on 429 (the request was not processed).
+	return isIdempotentMethod(method) || statusCode == http.StatusTooManyRequests
+}
+
 // retryDelay calculates delay with exponential backoff, jitter, and Retry-After support.
 func retryDelay(attempt int, cfg RetryConfig, resp *http.Response) time.Duration {
 	// Check Retry-After header first.


### PR DESCRIPTION
## What

Gate generated-client status-code retries by HTTP method. Non-idempotent methods (POST/PATCH) now only retry on **429**; idempotent methods (GET/HEAD/OPTIONS/PUT/DELETE) keep retrying on all configured retryable status codes. Also closes any response body a middleware returns alongside a transport error.

## Why

The generated `do()` retried **every** method on retryable status codes:

```go
if c.retryConfig != nil && attempt < maxAttempts-1 && shouldRetry(resp.StatusCode, *c.retryConfig) {
```

With retries enabled, a transient `502/503/504` on a `POST` would be replayed — and if the server had already processed the first request, that duplicates a create (duplicate clusters/workflows/sessions). The network-error retry path added earlier was already idempotent-only; this brings the status-code path in line. Surfaced when enabling retries in the `pw` CLI (parallelworks/core#15993).

## Design

- New `shouldRetryStatus(method, statusCode, cfg)` helper in `retry.go.tmpl`: retryable status **and** (idempotent method **or** 429).
- 429 is exempt because it means the request was not processed (rate limited), so retrying any method is safe.
- `client.go.tmpl` status-retry condition now calls `shouldRetryStatus(method, ...)`.
- Defensive `resp.Body.Close()` on the transport-error path (only matters for custom middleware that returns a non-nil response with a non-nil error; the base `http.Client.Do` already returns a nil/closed body on error).

## Testing

- `go test ./...` passes; `TestGenerate_RetriesTransientNetworkErrors` extended to assert the generated `retry.go`/`client.go` gate status retries by method.
- `TestE2E_PetstoreGeneration` compiles the generated output.
- Verified the generated predicate against a matrix: `POST 503 → no retry`, `POST 429 → retry`, `GET 503 → retry`, `PUT 504 → retry`, `POST 404 → no retry`.

https://claude.ai/code/session_0125ShxCQ8JRcK6GkbgaW49T