### PR TITLE
fix: emit required query parameters as positional arguments

### DIFF
--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -12,30 +12,31 @@ import (
 // FuncMap returns the template.FuncMap used by all templates.
 func FuncMap() template.FuncMap {
 	return template.FuncMap{
-		"cleanDoc":               cleanDoc,
-		"opDocComment":           opDocComment,
-		"typeDocComment":         typeDocComment,
-		"fieldDocComment":        fieldDocComment,
-		"paramDocComment":        paramDocComment,
-		"indent":                 indent,
-		"jsonTag":                jsonTag,
-		"enumLiteral":            enumLiteral,
-		"hasOperations":          hasOperations,
-		"successType":            successType,
-		"hasBody":                hasBody,
-		"hasOptionalParams":      hasOptionalParams,
+		"cleanDoc":                cleanDoc,
+		"opDocComment":            opDocComment,
+		"typeDocComment":          typeDocComment,
+		"fieldDocComment":         fieldDocComment,
+		"paramDocComment":         paramDocComment,
+		"indent":                  indent,
+		"jsonTag":                 jsonTag,
+		"enumLiteral":             enumLiteral,
+		"hasOperations":           hasOperations,
+		"successType":             successType,
+		"hasBody":                 hasBody,
+		"hasOptionalParams":       hasOptionalParams,
 		"hasOptionalQueryParams":  hasOptionalQueryParams,
+		"hasRequiredQueryParams":  hasRequiredQueryParams,
 		"hasOptionalHeaderParams": hasOptionalHeaderParams,
-		"paramType":              paramType,
-		"hasUnions":              hasUnions,
-		"discriminatorFieldName": discriminatorFieldName,
-		"hasPaginatedOps":        hasPaginatedOps,
-		"paginationItemType":     paginationItemType,
-		"paginationCursorField":  paginationCursorField,
-		"toGoName":               naming.ToGoName,
-		"uniqueErrorTypes":       uniqueErrorTypes,
-		"errorType":              errorType,
-		"successContentType":     successContentType,
+		"paramType":               paramType,
+		"hasUnions":               hasUnions,
+		"discriminatorFieldName":  discriminatorFieldName,
+		"hasPaginatedOps":         hasPaginatedOps,
+		"paginationItemType":      paginationItemType,
+		"paginationCursorField":   paginationCursorField,
+		"toGoName":                naming.ToGoName,
+		"uniqueErrorTypes":        uniqueErrorTypes,
+		"errorType":               errorType,
+		"successContentType":      successContentType,
 	}
 }
 
@@ -226,6 +227,18 @@ func hasOptionalParams(op *ir.OperationDef) bool {
 func hasOptionalQueryParams(op *ir.OperationDef) bool {
 	for _, p := range op.QueryParams {
 		if !p.Required {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRequiredQueryParams returns true if the operation has required query parameters.
+// These are emitted as positional method arguments (like path params) so callers
+// must supply them; otherwise the server rejects the request as missing a required param.
+func hasRequiredQueryParams(op *ir.OperationDef) bool {
+	for _, p := range op.QueryParams {
+		if p.Required {
 			return true
 		}
 	}

--- a/internal/generator/required_query_test.go
+++ b/internal/generator/required_query_test.go
@@ -1,0 +1,123 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/parallelworks/openapi-client-generator/internal/ir"
+)
+
+func TestHasRequiredQueryParams(t *testing.T) {
+	tests := []struct {
+		name string
+		op   *ir.OperationDef
+		want bool
+	}{
+		{name: "no params", op: &ir.OperationDef{}, want: false},
+		{
+			name: "required query param",
+			op:   &ir.OperationDef{QueryParams: []*ir.ParamDef{{Name: "startDate", Required: true}}},
+			want: true,
+		},
+		{
+			name: "only optional query param",
+			op:   &ir.OperationDef{QueryParams: []*ir.ParamDef{{Name: "limit", Required: false}}},
+			want: false,
+		},
+		{
+			name: "required header param does not count",
+			op:   &ir.OperationDef{HeaderParams: []*ir.ParamDef{{Name: "X-Request-Id", Required: true}}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasRequiredQueryParams(tt.op); got != tt.want {
+				t.Errorf("hasRequiredQueryParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGenerate_RequiredQueryParam_Compiles is a regression test for required
+// query parameters being dropped from the generated client. A required query
+// param must become a positional method argument and always be encoded; an
+// optional one stays in the params struct. The generated package must compile.
+func TestGenerate_RequiredQueryParam_Compiles(t *testing.T) {
+	pkg := &ir.Package{
+		Name: "reqquery",
+		Operations: []*ir.OperationDef{
+			{
+				Name:       "GetUsageSummary",
+				HTTPMethod: "GET",
+				Path:       "/things/{id}/usage",
+				PathParams: []*ir.ParamDef{
+					{Name: "id", FieldName: "ID", OrigName: "id", Location: "path", Type: "string", Required: true},
+				},
+				QueryParams: []*ir.ParamDef{
+					{Name: "startDate", FieldName: "StartDate", OrigName: "startDate", Location: "query", Type: "string", Required: true},
+					{Name: "endDate", FieldName: "EndDate", OrigName: "endDate", Location: "query", Type: "string", Required: false},
+				},
+			},
+		},
+	}
+
+	gen, err := New(pkg)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	var ops string
+	for _, f := range files {
+		if f.Name == "operations.go" {
+			ops = string(f.Content)
+		}
+	}
+	if ops == "" {
+		t.Fatal("operations.go not generated")
+	}
+
+	// The required query param must be a positional argument, not a struct field.
+	if !strings.Contains(ops, "startDate string") {
+		t.Errorf("required query param missing from method signature:\n%s", ops)
+	}
+	if strings.Contains(ops, "StartDate") {
+		t.Errorf("required query param leaked into the params struct (StartDate):\n%s", ops)
+	}
+	// The required param must be encoded unconditionally (from the positional arg).
+	if !strings.Contains(ops, `addQueryParam(queryValues, "startDate", startDate)`) {
+		t.Errorf("required query param not encoded into the query string:\n%s", ops)
+	}
+	// The optional param stays in the params struct and is encoded from opts.
+	if !strings.Contains(ops, "EndDate *string") {
+		t.Errorf("optional query param missing from params struct:\n%s", ops)
+	}
+	if !strings.Contains(ops, `addQueryParam(queryValues, "endDate", params.EndDate)`) {
+		t.Errorf("optional query param not encoded from opts:\n%s", ops)
+	}
+
+	// The whole generated package must compile.
+	tmpDir := t.TempDir()
+	goMod := []byte("module reqquery-e2e-test\n\ngo 1.25.5\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), goMod, 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+	if err := WriteFiles(tmpDir, files); err != nil {
+		t.Fatalf("WriteFiles: %v", err)
+	}
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = tmpDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		for _, f := range files {
+			t.Logf("=== %s ===\n%s", f.Name, string(f.Content))
+		}
+		t.Fatalf("generated code with a required query param failed to compile: %v\n%s", err, string(output))
+	}
+}

--- a/internal/templates/operations.go.tmpl
+++ b/internal/templates/operations.go.tmpl
@@ -20,23 +20,25 @@ type {{ .Name }}Params struct {
 {{ end }}{{ end }}}
 {{ end }}
 {{ $opDoc := opDocComment . }}{{ if $opDoc }}{{ $opDoc }}
-{{ end }}func (c *Client) {{ .Name }}(ctx context.Context{{ range .PathParams }}, {{ .Name }} {{ .Type }}{{ end }}{{ if hasBody . }}, body {{ if .RequestBody }}{{ if not .RequestBody.Required }}*{{ end }}{{ .RequestBody.TypeName }}{{ else }}any{{ end }}{{ end }}{{ if hasOptionalParams . }}, opts ...{{ .Name }}Params{{ end }}) {{ if successType . }}(*{{ successType . }}, error){{ else }}error{{ end }} {
+{{ end }}func (c *Client) {{ .Name }}(ctx context.Context{{ range .PathParams }}, {{ .Name }} {{ .Type }}{{ end }}{{ range .QueryParams }}{{ if .Required }}, {{ .Name }} {{ .Type }}{{ end }}{{ end }}{{ if hasBody . }}, body {{ if .RequestBody }}{{ if not .RequestBody.Required }}*{{ end }}{{ .RequestBody.TypeName }}{{ else }}any{{ end }}{{ end }}{{ if hasOptionalParams . }}, opts ...{{ .Name }}Params{{ end }}) {{ if successType . }}(*{{ successType . }}, error){{ else }}error{{ end }} {
 	path := "{{ .Path }}"
 {{ range .PathParams }}	path = pathReplace(path, "{{ .OrigName }}", {{ .Name }})
 {{ end }}
-{{ if hasOptionalParams . }}{{- $hasQuery := hasOptionalQueryParams . }}{{- $hasHeader := hasOptionalHeaderParams . }}{{ if $hasHeader }}	var headers http.Header
+{{- $hasReqQuery := hasRequiredQueryParams . }}{{- $hasOptQuery := hasOptionalQueryParams . }}{{- $hasOptHeader := hasOptionalHeaderParams . }}
+{{ if or $hasReqQuery $hasOptQuery }}	queryValues := url.Values{}
+{{ range .QueryParams }}{{ if .Required }}	addQueryParam(queryValues, "{{ .OrigName }}", {{ .Name }})
+{{ end }}{{ end }}{{ end }}{{ if hasOptionalParams . }}{{ if $hasOptHeader }}	var headers http.Header
 {{ end }}	if len(opts) > 0 {
 		params := opts[0]
-{{ if $hasQuery }}		queryValues := url.Values{}
 {{ range .QueryParams }}{{ if not .Required }}		addQueryParam(queryValues, "{{ .OrigName }}", params.{{ .FieldName }})
-{{ end }}{{ end }}		if len(queryValues) > 0 {
-			path += "?" + queryValues.Encode()
-		}
-{{ end }}{{ if $hasHeader }}		headers = make(http.Header)
+{{ end }}{{ end }}{{ if $hasOptHeader }}		headers = make(http.Header)
 {{ range .HeaderParams }}{{ if not .Required }}		if params.{{ .FieldName }} != nil {
 			headers.Set("{{ .OrigName }}", fmt.Sprintf("%v", *params.{{ .FieldName }}))
 		}
 {{ end }}{{ end }}{{ end }}	}
+{{ end }}{{ if or $hasReqQuery $hasOptQuery }}	if len(queryValues) > 0 {
+		path += "?" + queryValues.Encode()
+	}
 {{ end }}
 {{- $errType := errorType . -}}
 {{ if successType . }}	var result {{ successType . }}


### PR DESCRIPTION
## Problem

Required **query** parameters were dropped entirely from generated clients. The operations template (`operations.go.tmpl`) only emitted *optional* params — into the `...Params` struct and the query encoder — and gave *required* query params no positional argument either. So an endpoint with a required query param was **uncallable through the SDK**: the parameter could never be sent, and the server rejected every request as missing a required param.

The bug is systemic — it affects every operation with a required query param. Examples from the parallelworks/core spec:

| Operation | Required query param(s) | Before (broken) | After |
|---|---|---|---|
| `get-allocation-usage-events-summary` | `startDate` | `…(ctx, organization, allocation string, opts …Params)` — no way to send `startDate` | `…(ctx, organization, allocation, startDate string, opts …Params)` |
| `get-accelerators` | `csp` | `GetAccelerators(ctx, opts …Params)` | `GetAccelerators(ctx, csp string, opts …Params)` |
| `get-workflow-run-file` | `file` | `GetWorkflowRunFile(ctx, slug string)` | `GetWorkflowRunFile(ctx, slug, file string)` |
| `get-cluster-session-token` | `session_id, provider, name, session_number` | `GetClusterSessionToken(ctx)` — takes nothing | `GetClusterSessionToken(ctx, sessionID, provider, name, sessionNumber string)` |

## Fix

Required query params are now emitted as **positional method arguments** — consistent with path params, which are also always required — and always encoded into the query string. Optional params keep their place in the `...Params` struct, unchanged.

- `internal/templates/operations.go.tmpl`: required query params added to the method signature; `queryValues` built whenever there are any query params; required params encoded unconditionally, optional ones inside the `if len(opts) > 0` block.
- `internal/generator/funcmap.go`: new `hasRequiredQueryParams` helper.

## Tests

- `TestHasRequiredQueryParams` — unit test for the helper.
- `TestGenerate_RequiredQueryParam_Compiles` — generates an operation with one required and one optional query param, asserts the required one is a positional arg + always encoded (and did not leak into the params struct), and **compiles the generated package**.
- Full existing suite passes (incl. the petstore e2e compile test).
- Verified end-to-end by regenerating the full parallelworks/core spec (620 types) with this branch — it compiles, and the four operations above now take their required params.

## Note

This changes the generated signatures for operations that have required query params (a new positional argument). Those methods were non-functional before, so callers that regenerate will get a compile error pointing them at the now-required argument — which is the correct outcome.
