### PR TITLE
fix: stop duplicating the status code in generated API error strings

### DIFF
--- a/internal/templates/errors.go.tmpl
+++ b/internal/templates/errors.go.tmpl
@@ -35,10 +35,20 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	if len(e.Body) > 0 {
-		return fmt.Sprintf("API error %d %s: %s", e.StatusCode, e.Status, string(e.Body))
+	// Status already carries the code (e.g. "409 Conflict"); reconstruct it from StatusCode for the
+	// sentinel errors, which set only StatusCode, so the code is never printed twice.
+	status := e.Status
+	if status == "" {
+		if text := http.StatusText(e.StatusCode); text != "" {
+			status = fmt.Sprintf("%d %s", e.StatusCode, text)
+		} else {
+			status = fmt.Sprintf("%d", e.StatusCode)
+		}
 	}
-	return fmt.Sprintf("API error %d", e.StatusCode)
+	if len(e.Body) > 0 {
+		return fmt.Sprintf("API error %s: %s", status, e.Body)
+	}
+	return fmt.Sprintf("API error %s", status)
 }
 
 // Is supports errors.Is by matching on status code.
@@ -64,7 +74,7 @@ func (e *{{ . }}Response) Unwrap() error {
 	return e.APIError
 }
 
-func parse{{ . }}Error(err error) error {
+func parse{{ . }}Response(err error) error {
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) || len(apiErr.Body) == 0 {
 		return err

--- a/internal/templates/operations.go.tmpl
+++ b/internal/templates/operations.go.tmpl
@@ -43,11 +43,11 @@ type {{ .Name }}Params struct {
 {{- $errType := errorType . -}}
 {{ if successType . }}	var result {{ successType . }}
 	if err := c.do(ctx, "{{ .HTTPMethod }}", path, {{ if hasBody . }}body{{ else }}nil{{ end }}, &result, "{{ successContentType . }}"{{ if hasOptionalHeaderParams . }}, headers{{ end }}); err != nil {
-		return nil, {{ if $errType }}parse{{ $errType }}Error(err){{ else }}err{{ end }}
+		return nil, {{ if $errType }}parse{{ $errType }}Response(err){{ else }}err{{ end }}
 	}
 	return &result, nil
 {{ else }}	if err := c.do(ctx, "{{ .HTTPMethod }}", path, {{ if hasBody . }}body{{ else }}nil{{ end }}, nil, "{{ successContentType . }}"{{ if hasOptionalHeaderParams . }}, headers{{ end }}); err != nil {
-		return {{ if $errType }}parse{{ $errType }}Error(err){{ else }}err{{ end }}
+		return {{ if $errType }}parse{{ $errType }}Response(err){{ else }}err{{ end }}
 	}
 	return nil
 {{ end }}}


### PR DESCRIPTION
## What

Two fixes to generated Go clients' error handling:

- **`APIError.Error()` stops duplicating the status code.** `Status` already carries the code (Go sets it to e.g. `"409 Conflict"`), but the string was built with `"API error %d %s"` from `StatusCode` **and** `Status`, so a 409 rendered as `API error 409 409 Conflict: {body}`. It now prints the status once — `API error 409 Conflict: {body}` — and reconstructs it from `StatusCode` for the sentinel errors that carry no `Status`.
- **`parseErrorError` → `parseErrorResponse`.** The old name doubled up when the error schema is literally named `Error`; the function builds a `TResponse`, so the new name reads correctly.

## Why not surface a message field from `Error()`

An earlier version had `TResponse.Error()` return the parsed `Detail.Message`. That's wrong for a general generator: it drops the status code from the error string (lossy for logging), and it hardcodes a `Message` field that many specs don't use (RFC 7807 uses `detail`/`title`, OAuth uses `error`/`error_description`). Consumers that want a specific field already have it — the typed body is exposed as `TResponse.Detail`, read via `errors.As`. `Error()` stays a complete, general status+body diagnostic and doesn't guess which field is the human message.

## Behavior change

`err.Error()` output changes for the doubled-status case (`409 409` → `409`). Status-code matching via the `Err*` sentinels and `errors.Is` is unaffected; the typed `Detail` body is unchanged.

## Testing

- `go build ./...` and `go test ./...` pass (the e2e tests generate from the testdata specs and build/test the output).
- Generated the petstore client and confirmed `APIError.Error()` no longer doubles the status, `ErrorResponse.Error()` returns the complete string, call sites use `parseErrorResponse`, and the output compiles.

