### PR TITLE
feat: parsed error responses render the x-ms-primary-error-message field

### DIFF
--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -224,21 +224,42 @@ func (a *Analyzer) convertAllOf(goName string, schema *highbase.Schema, nullable
 			}
 
 			td.Fields = append(td.Fields, &ir.Field{
-				Name:        naming.ToGoFieldName(propName),
-				JSONName:    propName,
-				Type:        goType,
-				Description: propSchema.Description,
-				Required:    required,
-				IsPointer:   isPointer,
-				OmitEmpty:   !required,
-				Deprecated:  propSchema.Deprecated != nil && *propSchema.Deprecated,
-				ReadOnly:    propSchema.ReadOnly != nil && *propSchema.ReadOnly,
-				WriteOnly:   propSchema.WriteOnly != nil && *propSchema.WriteOnly,
+				Name:                naming.ToGoFieldName(propName),
+				JSONName:            propName,
+				Type:                goType,
+				Description:         propSchema.Description,
+				Required:            required,
+				IsPointer:           isPointer,
+				OmitEmpty:           !required,
+				Deprecated:          propSchema.Deprecated != nil && *propSchema.Deprecated,
+				ReadOnly:            propSchema.ReadOnly != nil && *propSchema.ReadOnly,
+				WriteOnly:           propSchema.WriteOnly != nil && *propSchema.WriteOnly,
+				PrimaryErrorMessage: isPrimaryErrorMessage(propSchema),
 			})
 		}
 	}
 
 	return td, nil
+}
+
+// isPrimaryErrorMessage reports whether a property schema carries Kiota's
+// x-ms-primary-error-message extension marking it as the human-readable
+// error message.
+func isPrimaryErrorMessage(schema *highbase.Schema) bool {
+	if schema.Extensions == nil {
+		return false
+	}
+	for name, node := range schema.Extensions.FromOldest() {
+		if name != "x-ms-primary-error-message" || node == nil {
+			continue
+		}
+		var enabled bool
+		if err := node.Decode(&enabled); err != nil {
+			return false
+		}
+		return enabled
+	}
+	return false
 }
 
 // convertOneOf creates a union TypeDef from a oneOf composition.
@@ -355,16 +376,17 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 		}
 
 		td.Fields = append(td.Fields, &ir.Field{
-			Name:        naming.ToGoFieldName(propName),
-			JSONName:    propName,
-			Type:        goType,
-			Description: propSchema.Description,
-			Required:    required,
-			IsPointer:   isPointer,
-			OmitEmpty:   !required,
-			Deprecated:  propSchema.Deprecated != nil && *propSchema.Deprecated,
-			ReadOnly:    propSchema.ReadOnly != nil && *propSchema.ReadOnly,
-			WriteOnly:   propSchema.WriteOnly != nil && *propSchema.WriteOnly,
+			Name:                naming.ToGoFieldName(propName),
+			JSONName:            propName,
+			Type:                goType,
+			Description:         propSchema.Description,
+			Required:            required,
+			IsPointer:           isPointer,
+			OmitEmpty:           !required,
+			Deprecated:          propSchema.Deprecated != nil && *propSchema.Deprecated,
+			ReadOnly:            propSchema.ReadOnly != nil && *propSchema.ReadOnly,
+			WriteOnly:           propSchema.WriteOnly != nil && *propSchema.WriteOnly,
+			PrimaryErrorMessage: isPrimaryErrorMessage(propSchema),
 		})
 	}
 

--- a/internal/generator/e2e_error_message_test.go
+++ b/internal/generator/e2e_error_message_test.go
@@ -1,0 +1,144 @@
+package generator
+
+import "testing"
+
+const errorMessageSpec = `openapi: "3.1.0"
+info:
+  title: Errmsg
+  version: 1.0.0
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Widget"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Failure"
+  /gadgets:
+    get:
+      operationId: listGadgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Widget"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /gizmos:
+    get:
+      operationId: listGizmos
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Widget"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bare"
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        id:
+          type: string
+    Failure:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          x-ms-primary-error-message: true
+    Problem:
+      type: object
+      properties:
+        title:
+          type: string
+        detail:
+          type: string
+          x-ms-primary-error-message: true
+    Bare:
+      type: object
+      properties:
+        message:
+          type: string
+`
+
+// TestE2E_ErrorResponseMessage verifies a parsed error response surfaces the
+// field annotated x-ms-primary-error-message instead of dumping the raw body,
+// for required (value) and optional (pointer) fields, and that unannotated
+// schemas keep the raw-body output.
+func TestE2E_ErrorResponseMessage(t *testing.T) {
+	files, _ := generateFromSpec(t, errorMessageSpec, "errmsg")
+
+	runtimeTest := `package errmsg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnnotatedMessageRendered(t *testing.T) {
+	err := parseFailureResponse(&APIError{StatusCode: 404, Status: "404 Not Found", Body: []byte(` + "`" + `{"message":"Widget not found"}` + "`" + `)})
+	if got := err.Error(); got != "API error 404 Not Found: Widget not found" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+func TestAnnotatedPointerFieldRendered(t *testing.T) {
+	err := parseProblemResponse(&APIError{StatusCode: 403, Status: "403 Forbidden", Body: []byte(` + "`" + `{"title":"Forbidden","detail":"Access denied"}` + "`" + `)})
+	if got := err.Error(); got != "API error 403 Forbidden: Access denied" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+func TestUnannotatedSchemaKeepsBody(t *testing.T) {
+	err := parseBareResponse(&APIError{StatusCode: 404, Status: "404 Not Found", Body: []byte(` + "`" + `{"message":"not rendered"}` + "`" + `)})
+	if got := err.Error(); !strings.Contains(got, ` + "`" + `{"message":"not rendered"}` + "`" + `) {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+func TestEmptyMessageFallsBackToBody(t *testing.T) {
+	err := parseFailureResponse(&APIError{StatusCode: 500, Status: "500 Internal Server Error", Body: []byte(` + "`" + `{"message":""}` + "`" + `)})
+	if got := err.Error(); !strings.Contains(got, ` + "`" + `{"message":""}` + "`" + `) {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+func TestUnparseableBodyFallsBackToBody(t *testing.T) {
+	err := parseFailureResponse(&APIError{StatusCode: 502, Status: "502 Bad Gateway", Body: []byte("upstream exploded")})
+	if got := err.Error(); got != "API error 502 Bad Gateway: upstream exploded" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+`
+	runGeneratedWireTest(t, files, "errmsg", runtimeTest)
+}

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -33,6 +33,7 @@ func FuncMap() template.FuncMap {
 		"paginationCursorField":   paginationCursorField,
 		"toGoName":                naming.ToGoName,
 		"uniqueErrorTypes":        uniqueErrorTypes,
+		"errorMessageField":       errorMessageField,
 		"errorType":               errorType,
 		"successContentType":      successContentType,
 	}
@@ -287,6 +288,22 @@ func uniqueErrorTypes(pkg *ir.Package) []string {
 		}
 	}
 	return types
+}
+
+// errorMessageField returns the error type's string field annotated with
+// x-ms-primary-error-message, or nil when the spec designates none.
+func errorMessageField(pkg *ir.Package, typeName string) *ir.Field {
+	for _, t := range pkg.Types {
+		if t.Name != typeName || t.Kind != ir.TypeKindStruct {
+			continue
+		}
+		for _, f := range t.Fields {
+			if f.PrimaryErrorMessage && (f.Type == "string" || f.Type == "*string") {
+				return f
+			}
+		}
+	}
+	return nil
 }
 
 // errorType returns the error response type name for an operation, or "".

--- a/internal/ir/types.go
+++ b/internal/ir/types.go
@@ -42,17 +42,18 @@ type TypeDef struct {
 
 // Field represents a struct field.
 type Field struct {
-	Name        string // Go field name (PascalCase)
-	JSONName    string // Original JSON property name (for struct tag)
-	Type        string // Go type expression (e.g., "string", "*int64", "[]User")
-	Description string
-	Required    bool
-	IsPointer   bool // Whether to use pointer type (nullable or optional)
-	OmitEmpty   bool // Whether to add omitempty to JSON tag
-	Embedded    bool // Whether this is an embedded (anonymous) field
-	Deprecated  bool
-	ReadOnly    bool
-	WriteOnly   bool
+	Name                string // Go field name (PascalCase)
+	JSONName            string // Original JSON property name (for struct tag)
+	Type                string // Go type expression (e.g., "string", "*int64", "[]User")
+	Description         string
+	Required            bool
+	IsPointer           bool // Whether to use pointer type (nullable or optional)
+	OmitEmpty           bool // Whether to add omitempty to JSON tag
+	Embedded            bool // Whether this is an embedded (anonymous) field
+	Deprecated          bool
+	ReadOnly            bool
+	WriteOnly           bool
+	PrimaryErrorMessage bool // Property annotated x-ms-primary-error-message
 }
 
 // EnumVal represents one value in an enum type.

--- a/internal/templates/errors.go.tmpl
+++ b/internal/templates/errors.go.tmpl
@@ -35,20 +35,23 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	// Status already carries the code (e.g. "409 Conflict"); reconstruct it from StatusCode for the
-	// sentinel errors, which set only StatusCode, so the code is never printed twice.
-	status := e.Status
-	if status == "" {
-		if text := http.StatusText(e.StatusCode); text != "" {
-			status = fmt.Sprintf("%d %s", e.StatusCode, text)
-		} else {
-			status = fmt.Sprintf("%d", e.StatusCode)
-		}
-	}
 	if len(e.Body) > 0 {
-		return fmt.Sprintf("API error %s: %s", status, e.Body)
+		return fmt.Sprintf("API error %s: %s", e.statusLabel(), e.Body)
 	}
-	return fmt.Sprintf("API error %s", status)
+	return fmt.Sprintf("API error %s", e.statusLabel())
+}
+
+// statusLabel reconstructs the label from StatusCode for the sentinel errors,
+// which set only StatusCode; Status already carries the code (e.g. "409
+// Conflict"), so the code is never printed twice.
+func (e *APIError) statusLabel() string {
+	if e.Status != "" {
+		return e.Status
+	}
+	if text := http.StatusText(e.StatusCode); text != "" {
+		return fmt.Sprintf("%d %s", e.StatusCode, text)
+	}
+	return fmt.Sprintf("%d", e.StatusCode)
 }
 
 // Is supports errors.Is by matching on status code.
@@ -67,6 +70,17 @@ type {{ . }}Response struct {
 }
 
 func (e *{{ . }}Response) Error() string {
+{{- with errorMessageField $ . }}
+{{- if .IsPointer }}
+	if e.Detail.{{ .Name }} != nil && *e.Detail.{{ .Name }} != "" {
+		return fmt.Sprintf("API error %s: %s", e.statusLabel(), *e.Detail.{{ .Name }})
+	}
+{{- else }}
+	if e.Detail.{{ .Name }} != "" {
+		return fmt.Sprintf("API error %s: %s", e.statusLabel(), e.Detail.{{ .Name }})
+	}
+{{- end }}
+{{- end }}
 	return e.APIError.Error()
 }
 


### PR DESCRIPTION
## What does this PR do?

When a generated `{Type}Response.Error()` has a successfully parsed `Detail` and the error schema explicitly designates a message property with Kiota's [`x-ms-primary-error-message: true`](https://learn.microsoft.com/en-us/openapi/kiota/errors) extension, the error string renders that field instead of dumping the raw response body:

```
API error 403 Forbidden: {"error":true,"message":"This model is not enabled","errors":[]}
```

becomes

```
API error 403 Forbidden: This model is not enabled
```

The designation is entirely spec-driven and opt-in: no field-name sniffing or invented conventions. We adopt the existing, documented Kiota extension rather than defining our own. Schemas without the annotation, empty messages, and unparseable bodies all keep the existing raw-body output. `APIError.Error()` is unchanged; its status formatting is extracted into a shared `statusLabel()`.

Both required (value) and optional (pointer) string fields are supported.

## Why is this PR needed?

Consumers surface these error strings directly to users (CLI output, logs), and a raw JSON dump reads as a debug artifact rather than an error message. The parsed `Detail` already carries the message — the string form just never used it. An explicit annotation keeps the generator general-purpose while letting a spec opt its error schema in.

## Steps to Reproduce

Generate a client from a spec whose error schema marks a string property with `x-ms-primary-error-message: true`, trigger a non-2xx response on a typed operation, and print the returned error. The new `TestE2E_ErrorResponseMessage` covers the annotated value-field, annotated pointer-field, unannotated-schema, empty-message, and unparseable-body cases against compiled generated code.