### PR TITLE
feat: configurable User-Agent for generated clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ openapi-client-generator generate --spec petstore.yaml --out ./gen/petstore
 | `--spec` | `-s` | Path to OpenAPI spec file (required) |
 | `--out` | `-o` | Output directory for generated code (required) |
 | `--package` | `-p` | Go package name (default: derived from output dir) |
+| `--user-agent` | | Default `User-Agent` for generated clients (default `openapi-client-generator/1.0`) |
 | `--allow-remote-refs` | | Allow fetching remote `$ref` targets |
 
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -16,6 +16,7 @@ var generateFlags struct {
 	specPath        string
 	outputDir       string
 	packageName     string
+	userAgent       string
 	allowRemoteRefs bool
 }
 
@@ -25,6 +26,7 @@ func init() {
 	generateCmd.Flags().StringVarP(&generateFlags.specPath, "spec", "s", "", "path to OpenAPI spec file (required)")
 	generateCmd.Flags().StringVarP(&generateFlags.outputDir, "out", "o", "", "output directory for generated code (required)")
 	generateCmd.Flags().StringVarP(&generateFlags.packageName, "package", "p", "", "Go package name (default: derived from output dir)")
+	generateCmd.Flags().StringVar(&generateFlags.userAgent, "user-agent", "", `default User-Agent for generated clients (default "openapi-client-generator/1.0")`)
 	generateCmd.Flags().BoolVar(&generateFlags.allowRemoteRefs, "allow-remote-refs", false, "allow fetching remote $ref targets")
 
 	generateCmd.MarkFlagRequired("spec")
@@ -43,11 +45,11 @@ var generateCmd = &cobra.Command{
 			packageName = derivePackageName(generateFlags.outputDir)
 		}
 
-		return generate(generateFlags.specPath, generateFlags.outputDir, packageName, generateFlags.allowRemoteRefs)
+		return generate(generateFlags.specPath, generateFlags.outputDir, packageName, generateFlags.userAgent, generateFlags.allowRemoteRefs)
 	},
 }
 
-func generate(specPath, outputDir, packageName string, allowRemoteRefs bool) error {
+func generate(specPath, outputDir, packageName, userAgent string, allowRemoteRefs bool) error {
 	result, err := parser.Parse(specPath, parser.Config{
 		AllowRemoteRefs: allowRemoteRefs,
 	})
@@ -61,6 +63,7 @@ func generate(specPath, outputDir, packageName string, allowRemoteRefs bool) err
 	if err != nil {
 		return fmt.Errorf("analyzing spec: %w", err)
 	}
+	pkg.UserAgent = userAgent
 
 	gen, err := generator.New(pkg)
 	if err != nil {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -21,11 +21,16 @@ type GeneratedFile struct {
 	Content []byte
 }
 
+const defaultUserAgent = "openapi-client-generator/1.0"
+
 // New creates a Generator for the given IR package, parsing all embedded templates.
 func New(pkg *ir.Package) (*Generator, error) {
 	tmpl, err := template.New("").Funcs(FuncMap()).ParseFS(templates.TemplateFS, "*.tmpl")
 	if err != nil {
 		return nil, fmt.Errorf("parsing templates: %w", err)
+	}
+	if pkg.UserAgent == "" {
+		pkg.UserAgent = defaultUserAgent
 	}
 	return &Generator{pkg: pkg, templates: tmpl}, nil
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -171,6 +171,40 @@ func TestGenerate_GoimportsSucceeds(t *testing.T) {
 	}
 }
 
+func TestGenerate_UserAgent(t *testing.T) {
+	clientContent := func(pkg *ir.Package) string {
+		gen, err := New(pkg)
+		if err != nil {
+			t.Fatalf("New() error: %v", err)
+		}
+		files, err := gen.Generate()
+		if err != nil {
+			t.Fatalf("Generate() error: %v", err)
+		}
+		for _, f := range files {
+			if f.Name == "client.go" {
+				return string(f.Content)
+			}
+		}
+		t.Fatal("expected client.go in generated files")
+		return ""
+	}
+
+	t.Run("custom user agent", func(t *testing.T) {
+		content := clientContent(&ir.Package{Name: "testpkg", UserAgent: "myproduct-sdk/2"})
+		if !strings.Contains(content, `userAgent:  "myproduct-sdk/2",`) {
+			t.Error("output missing custom userAgent default")
+		}
+	})
+
+	t.Run("default user agent", func(t *testing.T) {
+		content := clientContent(&ir.Package{Name: "testpkg"})
+		if !strings.Contains(content, `userAgent:  "openapi-client-generator/1.0",`) {
+			t.Error("output missing default userAgent")
+		}
+	})
+}
+
 func TestGenerate_AliasType(t *testing.T) {
 	pkg := &ir.Package{
 		Name: "testpkg",

--- a/internal/ir/package.go
+++ b/internal/ir/package.go
@@ -2,12 +2,13 @@ package ir
 
 // Package is the top-level IR representing the entire generated package.
 type Package struct {
-	Name        string           // Go package name
-	Types       []*TypeDef       // All type definitions
-	Operations  []*OperationDef  // All API operations
-	AuthSchemes []*AuthScheme    // Security schemes from the spec
-	ServerURLs  []string         // Default server URLs
-	Info        *APIInfo         // API title, version, description
+	Name        string          // Go package name
+	Types       []*TypeDef      // All type definitions
+	Operations  []*OperationDef // All API operations
+	AuthSchemes []*AuthScheme   // Security schemes from the spec
+	ServerURLs  []string        // Default server URLs
+	Info        *APIInfo        // API title, version, description
+	UserAgent   string          // Default User-Agent for generated clients
 }
 
 // APIInfo contains metadata about the API.

--- a/internal/templates/client.go.tmpl
+++ b/internal/templates/client.go.tmpl
@@ -28,7 +28,7 @@ func NewClient(baseURL string, opts ...ClientOption) *Client {
 	c := &Client{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		httpClient: http.DefaultClient,
-		userAgent:  "openapi-client-generator/1.0",
+		userAgent:  {{ printf "%q" .UserAgent }},
 	}
 	for _, opt := range opts {
 		opt(c)


### PR DESCRIPTION
## What does this PR do?

Adds a `--user-agent` flag to `generate` that sets the default User-Agent baked into the generated `NewClient`. When omitted, the default stays `openapi-client-generator/1.0`, so existing consumers are unaffected. `WithUserAgent` still overrides at runtime as before.

## Why is this PR needed?

The generated client identifies itself as the codegen tool (`openapi-client-generator/1.0`) rather than the SDK built from it, so every SDK consumer shows up in server-side telemetry under the tool's name.


## Steps to Reproduce

```sh
go run . generate -s testdata/petstore.yaml -o /tmp/petstore --user-agent myproduct-sdk/2
grep userAgent /tmp/petstore/client.go   # userAgent:  "myproduct-sdk/2"

go run . generate -s testdata/petstore.yaml -o /tmp/petstore2
grep userAgent /tmp/petstore2/client.go  # userAgent:  "openapi-client-generator/1.0"
```

`go test ./...` passes, including the generate-and-compile e2e suite and a new unit test covering both the flag-set and default paths.