### PR TITLE
fix: unions used as a request or response body generate typed instead of any

### DIFF
--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -789,6 +789,8 @@ func TestComplexSchemas_AllTypesPresent(t *testing.T) {
 		"StringOrInt", "Metadata", "Labels", "Config",
 		"DogOrCircle", "Timestamped", "TimestampedDog",
 		"ShapeCollection", "ShapeCollectionShapesValue",
+		// Unions used directly as a request or response body.
+		"CreateShapeBody", "CreateShapeResponse", "NamedShape",
 	}
 
 	if len(pkg.Types) != len(expectedTypes) {

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -83,7 +83,7 @@ func (a *Analyzer) convertOperation(httpMethod, path string, pathItem *v3high.Pa
 
 	// Request body.
 	if op.RequestBody != nil {
-		rbDef, err := a.convertRequestBody(op.RequestBody)
+		rbDef, err := a.convertRequestBody(op.RequestBody, name+"Body")
 		if err != nil {
 			return nil, fmt.Errorf("converting request body: %w", err)
 		}
@@ -92,7 +92,7 @@ func (a *Analyzer) convertOperation(httpMethod, path string, pathItem *v3high.Pa
 
 	// Responses.
 	if op.Responses != nil {
-		a.convertResponses(op.Responses, opDef)
+		a.convertResponses(op.Responses, opDef, name+"Response")
 	}
 
 	// Security requirements.
@@ -258,7 +258,7 @@ func effectiveStyleExplode(param *v3high.Parameter) (string, bool) {
 }
 
 // convertRequestBody converts an OpenAPI request body to an ir.RequestBodyDef.
-func (a *Analyzer) convertRequestBody(rb *v3high.RequestBody) (*ir.RequestBodyDef, error) {
+func (a *Analyzer) convertRequestBody(rb *v3high.RequestBody, nameHint string) (*ir.RequestBodyDef, error) {
 	def := &ir.RequestBodyDef{
 		Required:    rb.Required != nil && *rb.Required,
 		Description: rb.Description,
@@ -272,13 +272,13 @@ func (a *Analyzer) convertRequestBody(rb *v3high.RequestBody) (*ir.RequestBodyDe
 	for contentType, mediaType := range rb.Content.FromOldest() {
 		if strings.Contains(contentType, "json") {
 			def.ContentType = contentType
-			def.TypeName = a.resolveMediaTypeSchema(mediaType)
+			def.TypeName = a.resolveMediaTypeSchema(mediaType, nameHint)
 			break
 		}
 		if strings.Contains(contentType, "multipart") {
 			def.ContentType = contentType
 			def.IsMultipart = true
-			def.TypeName = a.resolveMediaTypeSchema(mediaType)
+			def.TypeName = a.resolveMediaTypeSchema(mediaType, nameHint)
 			break
 		}
 	}
@@ -287,7 +287,7 @@ func (a *Analyzer) convertRequestBody(rb *v3high.RequestBody) (*ir.RequestBodyDe
 	if def.ContentType == "" {
 		for contentType, mediaType := range rb.Content.FromOldest() {
 			def.ContentType = contentType
-			def.TypeName = a.resolveMediaTypeSchema(mediaType)
+			def.TypeName = a.resolveMediaTypeSchema(mediaType, nameHint)
 			break
 		}
 	}
@@ -296,10 +296,10 @@ func (a *Analyzer) convertRequestBody(rb *v3high.RequestBody) (*ir.RequestBodyDe
 }
 
 // convertResponses converts operation responses into the OperationDef fields.
-func (a *Analyzer) convertResponses(responses *v3high.Responses, opDef *ir.OperationDef) {
+func (a *Analyzer) convertResponses(responses *v3high.Responses, opDef *ir.OperationDef, nameHint string) {
 	if responses.Codes != nil {
 		for code, resp := range responses.Codes.FromOldest() {
-			rd := a.convertSingleResponse(code, resp)
+			rd := a.convertSingleResponse(code, resp, nameHint)
 			opDef.Responses = append(opDef.Responses, rd)
 
 			if isSuccessCode(code) {
@@ -315,7 +315,7 @@ func (a *Analyzer) convertResponses(responses *v3high.Responses, opDef *ir.Opera
 
 	// Handle the default response.
 	if responses.Default != nil {
-		rd := a.convertSingleResponse("default", responses.Default)
+		rd := a.convertSingleResponse("default", responses.Default, nameHint)
 		rd.IsError = true
 		opDef.Responses = append(opDef.Responses, rd)
 		opDef.ErrorResponses = append(opDef.ErrorResponses, rd)
@@ -323,7 +323,7 @@ func (a *Analyzer) convertResponses(responses *v3high.Responses, opDef *ir.Opera
 }
 
 // convertSingleResponse converts one response code/definition to an ir.ResponseDef.
-func (a *Analyzer) convertSingleResponse(code string, resp *v3high.Response) *ir.ResponseDef {
+func (a *Analyzer) convertSingleResponse(code string, resp *v3high.Response, nameHint string) *ir.ResponseDef {
 	rd := &ir.ResponseDef{
 		StatusCode:  code,
 		Description: resp.Description,
@@ -333,7 +333,7 @@ func (a *Analyzer) convertSingleResponse(code string, resp *v3high.Response) *ir
 		for contentType, mediaType := range resp.Content.FromOldest() {
 			if strings.Contains(contentType, "json") {
 				rd.ContentType = contentType
-				rd.TypeName = a.resolveMediaTypeSchema(mediaType)
+				rd.TypeName = a.resolveMediaTypeSchema(mediaType, nameHint)
 				break
 			}
 		}
@@ -341,7 +341,7 @@ func (a *Analyzer) convertSingleResponse(code string, resp *v3high.Response) *ir
 		if rd.ContentType == "" {
 			for contentType, mediaType := range resp.Content.FromOldest() {
 				rd.ContentType = contentType
-				rd.TypeName = a.resolveMediaTypeSchema(mediaType)
+				rd.TypeName = a.resolveMediaTypeSchema(mediaType, nameHint)
 				if rd.TypeName == "" && strings.HasPrefix(contentType, "text/") {
 					rd.TypeName = "string"
 				}
@@ -354,7 +354,7 @@ func (a *Analyzer) convertSingleResponse(code string, resp *v3high.Response) *ir
 }
 
 // resolveMediaTypeSchema extracts the Go type name from a media type's schema.
-func (a *Analyzer) resolveMediaTypeSchema(mt *v3high.MediaType) string {
+func (a *Analyzer) resolveMediaTypeSchema(mt *v3high.MediaType, nameHint string) string {
 	if mt == nil || mt.Schema == nil {
 		return ""
 	}
@@ -375,7 +375,7 @@ func (a *Analyzer) resolveMediaTypeSchema(mt *v3high.MediaType) string {
 	if err != nil || schema == nil {
 		return ""
 	}
-	return a.resolveGoType(schema, "")
+	return a.resolveGoType(schema, nameHint)
 }
 
 // convertSecurityReqs converts OpenAPI security requirements to IR.

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -541,6 +541,12 @@ func (a *Analyzer) synthesizeInlineUnion(schema *highbase.Schema, nameHint strin
 		variants = schema.AnyOf
 		kind = "anyOf"
 	}
+	// A titled union names itself, which keeps the generated name stable when
+	// the operation that reaches it first changes. Untitled unions fall back to
+	// the caller's hint.
+	if schema.Title != "" {
+		nameHint = schema.Title
+	}
 	if len(variants) == 0 || nameHint == "" {
 		return "", false
 	}

--- a/internal/analyzer/schemas_body_union_test.go
+++ b/internal/analyzer/schemas_body_union_test.go
@@ -1,0 +1,68 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/parallelworks/openapi-client-generator/internal/ir"
+)
+
+func operationByName(t *testing.T, pkg *ir.Package, name string) *ir.OperationDef {
+	t.Helper()
+	for _, op := range pkg.Operations {
+		if op.Name == name {
+			return op
+		}
+	}
+	t.Fatalf("operation %q not found", name)
+	return nil
+}
+
+// A union used directly as a request or response body used to degrade to any,
+// because the body path resolved its type without a naming hint.
+func TestInlineUnionInBodyStaysTyped(t *testing.T) {
+	pkg, typeMap := parseComplexSchemas(t)
+
+	op := operationByName(t, pkg, "CreateShape")
+	if op.RequestBody == nil {
+		t.Fatal("CreateShape: missing request body")
+	}
+	if op.RequestBody.TypeName != "CreateShapeBody" {
+		t.Errorf("request body type = %q, want CreateShapeBody", op.RequestBody.TypeName)
+	}
+	if op.SuccessResponse == nil || op.SuccessResponse.TypeName != "CreateShapeResponse" {
+		t.Errorf("response type = %q, want CreateShapeResponse", op.SuccessResponse.TypeName)
+	}
+
+	for _, name := range []string{"CreateShapeBody", "CreateShapeResponse"} {
+		td := typeMap[name]
+		if td == nil {
+			t.Fatalf("synthesized union %s not found", name)
+		}
+		if td.Kind != ir.TypeKindUnion {
+			t.Errorf("%s kind = %v, want union", name, td.Kind)
+		}
+		if len(td.UnionTypes) != 2 {
+			t.Errorf("%s has %d variants, want 2", name, len(td.UnionTypes))
+		}
+	}
+}
+
+// A titled union names itself, so the generated name does not move when the
+// operation that reaches it first changes.
+func TestTitledBodyUnionNamesItself(t *testing.T) {
+	pkg, typeMap := parseComplexSchemas(t)
+
+	op := operationByName(t, pkg, "CreateTitledShape")
+	if op.RequestBody == nil {
+		t.Fatal("CreateTitledShape: missing request body")
+	}
+	if op.RequestBody.TypeName != "NamedShape" {
+		t.Errorf("request body type = %q, want NamedShape from the schema title", op.RequestBody.TypeName)
+	}
+	if typeMap["NamedShape"] == nil {
+		t.Fatal("synthesized union NamedShape not found")
+	}
+	if typeMap["CreateTitledShapeBody"] != nil {
+		t.Error("the operation hint should not be used when the schema is titled")
+	}
+}

--- a/testdata/complex-schemas.yaml
+++ b/testdata/complex-schemas.yaml
@@ -5,7 +5,57 @@ info:
   description: Test spec for advanced schema composition
 servers:
   - url: https://api.example.com/v1
-paths: {}
+paths:
+  /shapes:
+    post:
+      operationId: createShape
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/Circle"
+                - $ref: "#/components/schemas/Rectangle"
+              discriminator:
+                propertyName: kind
+                mapping:
+                  circle: "#/components/schemas/Circle"
+                  rectangle: "#/components/schemas/Rectangle"
+      responses:
+        "200":
+          description: the stored shape
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Dog"
+                  - $ref: "#/components/schemas/Rectangle"
+                discriminator:
+                  propertyName: kind
+                  mapping:
+                    dog: "#/components/schemas/Dog"
+                    rectangle: "#/components/schemas/Rectangle"
+  /titled-shapes:
+    post:
+      operationId: createTitledShape
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: NamedShape
+              oneOf:
+                - $ref: "#/components/schemas/Circle"
+                - $ref: "#/components/schemas/Dog"
+              discriminator:
+                propertyName: kind
+                mapping:
+                  circle: "#/components/schemas/Circle"
+                  dog: "#/components/schemas/Dog"
+      responses:
+        "204":
+          description: stored
 components:
   schemas:
     # --- Base types ---


### PR DESCRIPTION
## What

A `oneOf`/`anyOf` schema used directly as a request or response body generated `any`. It now generates the same typed union the generator already produces elsewhere.

The synthesis path existed and worked; it was simply never reached from bodies. `synthesizeInlineUnion` returns false without a naming hint, and the body path resolved with an empty one:

```go
// operations.go, before
return a.resolveGoType(schema, "")
```

This threads the operation's Go name down through `convertRequestBody`, `convertResponses`, `convertSingleResponse`, and `resolveMediaTypeSchema`, so a body union is named `<Operation>Body` or `<Operation>Response`.

## Titled unions name themselves

Synthesized unions are deduplicated by variant refs and discriminator, so a union shared by several operations is named after whichever one the spec reaches first. That is order-dependent: inserting a route earlier renames existing generated types, which is churn for consumers that diff-gate their SDK.

So a `title` on the union now wins over the operation hint. A spec that names its unions gets stable names regardless of route order; a spec that does not still improves from `any`.

## Effect on a real spec

Against the Parallel Works API (754 types), before:

```go
func (c *Client) GetClusterAttachedStorages(...) (*[]any, error)
func (c *Client) AttachClusterStorage(..., body any) (*[]any, error)
func (c *Client) GetClusterDefinition(...) (*any, error)
```

after, with `title` set on the two attached-storage unions and nothing else changed:

```go
func (c *Client) GetClusterAttachedStorages(...) (*[]AttachedStorage, error)
func (c *Client) AttachClusterStorage(..., body AttachedStorageWrite) (*[]AttachedStorage, error)
func (c *Client) GetClusterDefinition(...) (*GetClusterDefinitionResponse, error)
```

The generated union carries the discriminator-driven `UnmarshalJSON`, so decoding yields the concrete variant rather than a map.

## Tests

`testdata/complex-schemas.yaml` gains two paths: one with untitled union bodies, one titled. New tests assert the untitled bodies take the operation hint, that an identical union elsewhere still deduplicates, and that a titled union uses its title and does not also emit a hint-named type. The exact-count assertion in `TestComplexSchemas_AllTypesPresent` is updated for the three new synthesized types.

Note this changes generated output for any spec with union bodies: those signatures move from `any` to a named type. That is the point, but it is a visible diff for consumers on regeneration.
