### PR TITLE
fix: additionalProperties are dropped on decode and sent as a "-" key

### DIFF
--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -753,6 +753,12 @@ func TestAdditionalProperties_WithProperties(t *testing.T) {
 	if apField.Type != "map[string]string" {
 		t.Errorf("Config.AdditionalProperties type = %q, want map[string]string", apField.Type)
 	}
+	if !apField.CatchAll {
+		t.Error("Config.AdditionalProperties should be marked CatchAll")
+	}
+	if apField.OmitEmpty {
+		t.Error("Config.AdditionalProperties must not set OmitEmpty; the tag has to stay exactly \"-\"")
+	}
 }
 
 func TestOneOf_DogOrCircle(t *testing.T) {

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -391,13 +391,16 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 	}
 
 	// If the object has both properties and additionalProperties, add an extra field.
+	// The generator gives such structs MarshalJSON/UnmarshalJSON so the map is
+	// inlined into the object rather than nested under a key of its own.
 	if schema.AdditionalProperties != nil {
 		mapValueType := a.resolveAdditionalPropertiesType(schema, goName)
 		td.Fields = append(td.Fields, &ir.Field{
-			Name:      "AdditionalProperties",
-			JSONName:  "-",
-			Type:      "map[string]" + mapValueType,
-			OmitEmpty: true,
+			Name:        "AdditionalProperties",
+			JSONName:    "-",
+			Type:        "map[string]" + mapValueType,
+			Description: "Properties not defined by the schema.",
+			CatchAll:    true,
 		})
 	}
 

--- a/internal/generator/e2e_additional_properties_test.go
+++ b/internal/generator/e2e_additional_properties_test.go
@@ -1,0 +1,176 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/parallelworks/openapi-client-generator/internal/analyzer"
+	"github.com/parallelworks/openapi-client-generator/internal/parser"
+)
+
+const additionalPropertiesSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /pets/{id}:
+    get:
+      operationId: getPet
+      parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Pet" }
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        tag: { type: string }
+      additionalProperties: true
+    Labels:
+      type: object
+      properties:
+        owner: { type: string }
+      additionalProperties:
+        type: string
+`
+
+// TestE2E_AdditionalPropertiesRoundTrip generates a client for schemas that mix
+// declared properties with additionalProperties, then compiles and RUNS a test
+// proving unknown keys survive an unmarshal/marshal round trip instead of being
+// dropped or emitted under a literal "-" key.
+func TestE2E_AdditionalPropertiesRoundTrip(t *testing.T) {
+	specDir := t.TempDir()
+	specPath := filepath.Join(specDir, "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(additionalPropertiesSpec), 0o644); err != nil {
+		t.Fatalf("writing spec: %v", err)
+	}
+
+	result, err := parser.Parse(specPath, parser.Config{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	a := analyzer.New(result.Model)
+	pkg, err := a.Analyze("petsapi")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	gen, err := New(pkg)
+	if err != nil {
+		t.Fatalf("New generator: %v", err)
+	}
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	goMod := []byte("module additionalprops-e2e-test\n\ngo 1.25.5\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), goMod, 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+	if err := WriteFiles(tmpDir, files); err != nil {
+		t.Fatalf("WriteFiles: %v", err)
+	}
+
+	runtimeTest := []byte(`package petsapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUnknownKeysSurviveRoundTrip(t *testing.T) {
+	const payload = ` + "`" + `{"name":"rex","nickname":"r","age":3}` + "`" + `
+
+	var p Pet
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Name != "rex" {
+		t.Errorf("Name = %q, want rex", p.Name)
+	}
+	if got := p.AdditionalProperties["nickname"]; got != "r" {
+		t.Errorf("AdditionalProperties[nickname] = %v, want r", got)
+	}
+	if got := p.AdditionalProperties["age"]; got != float64(3) {
+		t.Errorf("AdditionalProperties[age] = %v, want 3", got)
+	}
+	if _, ok := p.AdditionalProperties["name"]; ok {
+		t.Error("declared property leaked into AdditionalProperties")
+	}
+
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), ` + "`" + `"-"` + "`" + `) {
+		t.Errorf("marshal emitted a literal \"-\" key: %s", out)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	want := map[string]any{"name": "rex", "nickname": "r", "age": float64(3)}
+	if len(got) != len(want) {
+		t.Fatalf("round trip = %s, want %v", out, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("round trip[%s] = %v, want %v", k, got[k], v)
+		}
+	}
+}
+
+func TestTypedAdditionalProperties(t *testing.T) {
+	var l Labels
+	if err := json.Unmarshal([]byte(` + "`" + `{"owner":"me","env":"prod"}` + "`" + `), &l); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if l.Owner == nil || *l.Owner != "me" {
+		t.Errorf("Owner = %v, want me", l.Owner)
+	}
+	if l.AdditionalProperties["env"] != "prod" {
+		t.Errorf("AdditionalProperties[env] = %q, want prod", l.AdditionalProperties["env"])
+	}
+
+	out, err := json.Marshal(l)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), ` + "`" + `"env":"prod"` + "`" + `) {
+		t.Errorf("marshal dropped the additional property: %s", out)
+	}
+}
+
+func TestEmptyAdditionalPropertiesOmitsNothingExtra(t *testing.T) {
+	out, err := json.Marshal(Pet{Name: "rex"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != ` + "`" + `{"name":"rex"}` + "`" + ` {
+		t.Errorf("marshal = %s, want {\"name\":\"rex\"}", out)
+	}
+}
+`)
+	if err := os.WriteFile(filepath.Join(tmpDir, "additional_properties_test.go"), runtimeTest, 0o644); err != nil {
+		t.Fatalf("writing runtime test: %v", err)
+	}
+
+	cmd := exec.Command("go", "test", "./...")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go test on generated code failed: %v\n%s", err, string(output))
+	}
+	t.Logf("additionalProperties round trip test passed:\n%s", string(output))
+}

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -27,6 +27,10 @@ func FuncMap() template.FuncMap {
 		"hasRequiredCookieParams": hasRequiredCookieParams,
 		"paramType":               paramType,
 		"hasUnions":               hasUnions,
+		"catchAllField":           catchAllField,
+		"catchAllValueType":       catchAllValueType,
+		"declaredJSONNames":       declaredJSONNames,
+		"hasCatchAllTypes":        hasCatchAllTypes,
 		"discriminatorFieldName":  discriminatorFieldName,
 		"hasPaginatedOps":         hasPaginatedOps,
 		"paginationItemType":      paginationItemType,
@@ -176,11 +180,54 @@ func indent(s string) string {
 // jsonTag returns the JSON struct tag value for a field.
 // It returns "fieldName,omitempty" for optional fields and "fieldName" for required ones.
 func jsonTag(f *ir.Field) string {
+	// encoding/json only skips a field when the tag is exactly "-"; appending
+	// anything turns it into a property literally named "-".
+	if f.JSONName == "-" {
+		return "-"
+	}
 	tag := f.JSONName
 	if f.OmitEmpty {
 		tag += ",omitempty"
 	}
 	return tag
+}
+
+// catchAllField returns the synthetic additionalProperties field of a struct, if any.
+func catchAllField(td *ir.TypeDef) *ir.Field {
+	if td.Kind != ir.TypeKindStruct {
+		return nil
+	}
+	for _, f := range td.Fields {
+		if f.CatchAll {
+			return f
+		}
+	}
+	return nil
+}
+
+// catchAllValueType returns the map value type of a catch-all field, e.g. "any"
+// for a map[string]any.
+func catchAllValueType(f *ir.Field) string {
+	return strings.TrimPrefix(f.Type, "map[string]")
+}
+
+// declaredJSONNames returns the wire names of a struct's non-catch-all fields.
+func declaredJSONNames(td *ir.TypeDef) []string {
+	var names []string
+	for _, f := range td.Fields {
+		if f.CatchAll || f.Embedded || f.JSONName == "" || f.JSONName == "-" {
+			continue
+		}
+		names = append(names, f.JSONName)
+	}
+	return names
+}
+
+// hasCatchAllTypes returns true if any type needs the additionalProperties marshalers.
+func hasCatchAllTypes(types []*ir.TypeDef) bool {
+	return slices.ContainsFunc(types, func(td *ir.TypeDef) bool {
+		return catchAllField(td) != nil
+	})
 }
 
 // hasOperations returns true if the package has any operations defined.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -503,6 +503,7 @@ func TestJsonTag(t *testing.T) {
 		{&ir.Field{JSONName: "name"}, "name"},
 		{&ir.Field{JSONName: "tag", OmitEmpty: true}, "tag,omitempty"},
 		{&ir.Field{JSONName: "id", OmitEmpty: false}, "id"},
+		{&ir.Field{JSONName: "-", OmitEmpty: true}, "-"},
 	}
 	for _, tt := range tests {
 		got := jsonTag(tt.field)

--- a/internal/ir/types.go
+++ b/internal/ir/types.go
@@ -54,6 +54,7 @@ type Field struct {
 	ReadOnly            bool
 	WriteOnly           bool
 	PrimaryErrorMessage bool // Property annotated x-ms-primary-error-message
+	CatchAll            bool // Synthetic field holding the schema's additionalProperties
 }
 
 // EnumVal represents one value in an enum type.

--- a/internal/templates/types.go.tmpl
+++ b/internal/templates/types.go.tmpl
@@ -3,7 +3,7 @@
 package {{ .Name }}
 
 import (
-{{- if hasUnions .Types }}
+{{- if or (hasUnions .Types) (hasCatchAllTypes .Types) }}
 	"encoding/json"
 	"fmt"
 {{- end }}
@@ -11,12 +11,78 @@ import (
 )
 
 {{ range .Types }}
-{{ $typeDoc := typeDocComment . }}{{ if eq .Kind 0 }}{{ if $typeDoc }}{{ $typeDoc }}
+{{ $typeDoc := typeDocComment . }}{{ if eq .Kind 0 }}{{ $typeName := .Name }}{{ $td := . }}{{ if $typeDoc }}{{ $typeDoc }}
 {{ end }}type {{ .Name }} struct {
 {{ range .Fields }}{{ $fDoc := fieldDocComment . }}{{ if $fDoc }}{{ indent $fDoc }}
 {{ end }}{{ if .Embedded }}	{{ .Type }}
 {{ else }}	{{ .Name }} {{ .Type }} `json:"{{ jsonTag . }}"`
 {{ end }}{{ end }}}
+{{ with catchAllField . }}
+// MarshalJSON implements json.Marshaler for {{ $typeName }}, inlining
+// {{ .Name }} alongside the schema's declared properties.
+func (t {{ $typeName }}) MarshalJSON() ([]byte, error) {
+	type shadow {{ $typeName }}
+	data, err := json.Marshal(shadow(t))
+	if err != nil {
+		return nil, err
+	}
+	if len(t.{{ .Name }}) == 0 {
+		return data, nil
+	}
+
+	obj := make(map[string]json.RawMessage, len(t.{{ .Name }}))
+	for key, value := range t.{{ .Name }} {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling additional property %q: %w", key, err)
+		}
+		obj[key] = raw
+	}
+	for _, name := range []string{ {{ range $i, $n := declaredJSONNames $td }}{{ if $i }}, {{ end }}{{ printf "%q" $n }}{{ end }} } {
+		delete(obj, name)
+	}
+
+	var declared map[string]json.RawMessage
+	if err := json.Unmarshal(data, &declared); err != nil {
+		return nil, err
+	}
+	for key, raw := range declared {
+		obj[key] = raw
+	}
+	return json.Marshal(obj)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for {{ $typeName }}, collecting
+// properties the schema does not declare into {{ .Name }}.
+func (t *{{ $typeName }}) UnmarshalJSON(data []byte) error {
+	type shadow {{ $typeName }}
+	var s shadow
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*t = {{ $typeName }}(s)
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	for _, name := range []string{ {{ range $i, $n := declaredJSONNames $td }}{{ if $i }}, {{ end }}{{ printf "%q" $n }}{{ end }} } {
+		delete(obj, name)
+	}
+	if len(obj) == 0 {
+		return nil
+	}
+	t.{{ .Name }} = make({{ .Type }}, len(obj))
+	for key, raw := range obj {
+		var value {{ catchAllValueType . }}
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return fmt.Errorf("unmarshaling additional property %q: %w", key, err)
+		}
+		t.{{ .Name }}[key] = value
+	}
+	return nil
+}
+{{ end }}
 {{ else if eq .Kind 1 }}{{ if $typeDoc }}{{ $typeDoc }}
 {{ end }}type {{ .Name }} = {{ .GoType }}
 {{ else if eq .Kind 2 }}{{ $typeName := .Name }}{{ if $typeDoc }}{{ $typeDoc }}


### PR DESCRIPTION
Fixes #38

## The bug

A struct with both `properties` and `additionalProperties` got a synthetic field tagged `json:"-,omitempty"`. `encoding/json` treats `-` as "skip" only when the tag is *exactly* `-`, so:

- **Marshal** emitted a property literally named `"-"` — a client that populated the map sent junk to the server.
- **Unmarshal** never populated it at all; unknown keys were discarded like any other struct decode.

Net effect: a read-modify-write against a replace-style endpoint silently dropped every field the client's build predated.

## The fix

Structs carrying an `additionalProperties` catch-all now get generated `MarshalJSON`/`UnmarshalJSON`:

- **Read** — decode declared fields via a shadow type, then re-decode into `map[string]json.RawMessage`, delete the declared wire names, and unmarshal what remains into the catch-all map (typed to the schema's `additionalProperties` value type, so `map[string]string` stays `map[string]string`).
- **Write** — marshal the catch-all entries, drop any that collide with a declared wire name, then overlay the declared properties so they always win.

An empty map short-circuits to the plain struct encoding, so output is byte-identical to before for anyone not using the field.

`jsonTag` also no longer appends `,omitempty` to a `-` name, so the tag is inert even for any future field that uses it.

Generated output for a `Config` with `name`, `version`, and `additionalProperties: {type: string}`:

```go
type Config struct {
	Name    string  `json:"name"`
	Version *string `json:"version,omitempty"`
	// Properties not defined by the schema.
	AdditionalProperties map[string]string `json:"-"`
}

func (t Config) MarshalJSON() ([]byte, error) { ... }
func (t *Config) UnmarshalJSON(data []byte) error { ... }
```

## Notes

- `allOf`-composed structs never carried a catch-all field, so embedded-field wire names can't leak into the map.
- Objects with `additionalProperties` and *no* declared properties still generate a plain map alias — unchanged.

## Tests

New `TestE2E_AdditionalPropertiesRoundTrip` generates a client from the issue's repro spec, compiles it, and runs it: unknown keys survive `{"name":"rex","nickname":"r","age":3}` → decode → encode, no `"-"` key appears, declared properties don't leak into the map, typed (`map[string]string`) catch-alls work, and an empty map still marshals to exactly `{"name":"rex"}`.

Analyzer and `jsonTag` unit tests cover the tag and the `CatchAll` flag. Full suite passes.