### PR TITLE
ci: run gofmt, vet, build, and tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - canary
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt'd:"
+            echo "$unformatted"
+            gofmt -d .
+            exit 1
+          fi
+
+      - name: build
+        run: go build ./...
+
+      - name: vet
+        run: go vet ./...
+
+      # Generates clients from the testdata specs and compiles/runs them, so a
+      # broken template fails here rather than in a consumer's build.
+      - name: test
+        run: go test ./...

--- a/internal/ir/auth.go
+++ b/internal/ir/auth.go
@@ -12,10 +12,10 @@ const (
 
 // AuthScheme represents a security scheme from the spec.
 type AuthScheme struct {
-	Name         string   // Identifier from the spec
-	GoName       string   // Go identifier
-	Type         AuthType
-	Description  string
+	Name        string // Identifier from the spec
+	GoName      string // Go identifier
+	Type        AuthType
+	Description string
 	// For APIKey:
 	APIKeyName string // Header/query parameter name
 	APIKeyIn   string // "header", "query", "cookie"

--- a/internal/ir/operations.go
+++ b/internal/ir/operations.go
@@ -2,11 +2,11 @@ package ir
 
 // OperationDef represents a single API operation.
 type OperationDef struct {
-	Name            string          // Go method name (e.g., "ListUsers")
-	Summary         string          // Short summary from the spec
+	Name            string // Go method name (e.g., "ListUsers")
+	Summary         string // Short summary from the spec
 	Description     string
-	HTTPMethod      string          // "GET", "POST", etc.
-	Path            string          // URL path template (e.g., "/users/{id}")
+	HTTPMethod      string // "GET", "POST", etc.
+	Path            string // URL path template (e.g., "/users/{id}")
 	Tags            []string
 	PathParams      []*ParamDef
 	QueryParams     []*ParamDef


### PR DESCRIPTION
## Why

The repo had **no CI**. `.github/workflows/` held only `release-please.yml`, which triggers on push to `canary` — nothing ran `go build`, `go test`, `gofmt`, or `go vet` against a branch before it merged. That's how `internal/ir/auth.go` and `internal/ir/operations.go` reached `canary` unformatted.

## What this adds

`.github/workflows/ci.yml`, on `pull_request` and on push to `canary`:

| Step | Command |
|------|---------|
| gofmt | `gofmt -l .`, failing with a diff if anything is unformatted |
| build | `go build ./...` |
| vet | `go vet ./...` |
| test | `go test ./...` |

- Go version comes from `go.mod` (`go-version-file`), so the toolchain tracks the module instead of drifting from a pinned string.
- Module cache enabled; `concurrency` cancels superseded runs on force-push.
- `permissions: contents: read` — the job needs nothing else.

The test step is the load-bearing one: `internal/generator`'s e2e tests generate clients from the testdata specs and then compile and *run* them, so a broken template fails in CI rather than in a consumer's build. The generated packages have no external dependencies, so those nested `go test` runs need no network.

## Also in this PR

`gofmt -w` on the two offending files — pure comment realignment in `AuthScheme` and `OperationDef`, no semantic change. Without it the new gofmt step fails on arrival.

## Still needed (org-level, not something a PR can set)

The `parallelworks` org ruleset applied to this repo's default branch requires 2 approvals, linear history, and squash merges — but has **no `required_status_checks` rule**. So even once this workflow exists, a red run won't block a merge. Adding `ci / build` as a required check on `~DEFAULT_BRANCH` would close that gap.