### PR TITLE
ci: harden the pipeline with lint, race tests, vulnerability, and CodeQL jobs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# The generator emits template bytes verbatim, so a CRLF checkout would leak
+# CRLF into every generated .go file.
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+defaults:
+  run:
+    # The Windows runner defaults to PowerShell, which mangles `-flag=value.ext`
+    # into two arguments.
+    shell: bash
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,17 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -34,13 +35,71 @@ jobs:
             exit 1
           fi
 
-      - name: build
-        run: go build ./...
+      - name: go mod tidy is a no-op
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
 
       - name: vet
         run: go vet ./...
 
-      # Generates clients from the testdata specs and compiles/runs them, so a
-      # broken template fails here rather than in a consumer's build.
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: build
+        run: go build ./...
+
+      # The generator's e2e tests write clients to a temp dir and compile and run
+      # them, so a broken template fails here rather than in a consumer's build.
       - name: test
-        run: go test ./...
+        run: go test -race -shuffle=on -coverprofile=coverage.out ./...
+
+      - name: coverage summary
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo '### Coverage' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          go tool cover -func=coverage.out | tail -n 20 >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          name: coverage
+          path: coverage.out
+          retention-days: 7
+
+  vulncheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      # Deliberately not go.mod's version: govulncheck reports standard-library
+      # advisories against the toolchain it runs with, and the go directive names
+      # the minimum supported release rather than the one to build with.
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: true
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: codeql
+
+on:
+  pull_request:
+  push:
+    branches:
+      - canary
+  schedule:
+    # Rerun weekly so newly published queries reach existing code.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          queries: security-and-quality
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - misspell
+    - usetesting
+  exclusions:
+    rules:
+      # Test helpers assert on the values they read; an unchecked error there is
+      # reported by the surrounding t.Fatal path.
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -29,8 +30,11 @@ func init() {
 	generateCmd.Flags().StringVar(&generateFlags.userAgent, "user-agent", "", `default User-Agent for generated clients (default "openapi-client-generator/1.0")`)
 	generateCmd.Flags().BoolVar(&generateFlags.allowRemoteRefs, "allow-remote-refs", false, "allow fetching remote $ref targets")
 
-	generateCmd.MarkFlagRequired("spec")
-	generateCmd.MarkFlagRequired("out")
+	// init cannot return, so a flag-registration failure is deferred to Execute.
+	setupErr = errors.Join(
+		generateCmd.MarkFlagRequired("spec"),
+		generateCmd.MarkFlagRequired("out"),
+	)
 }
 
 var generateCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,13 @@ var rootCmd = &cobra.Command{
 	Long:  "A code generator that produces feature-rich Go HTTP client packages from OpenAPI 3.1 specifications.",
 }
 
+// setupErr carries a failure from a command's init, which cannot return one.
+var setupErr error
+
 // Execute runs the root command.
 func Execute() error {
+	if setupErr != nil {
+		return setupErr
+	}
 	return rootCmd.Execute()
 }


### PR DESCRIPTION
Follow-up to #43, which added a deliberately minimal workflow to stop the bleeding. This brings it to what a public Go repo should actually have.

## What #43 left on the table

- One serial job, ubuntu only — the generator is `go install`ed on macOS and Windows too, and nothing exercised those paths.
- No linter beyond `go vet`.
- No race detector, no test shuffling.
- No dependency or vulnerability scanning, despite an open Dependabot alert on the repo.
- `actions/checkout@v4` and `actions/setup-go@v5` are on the deprecated Node 20 runtime — every run emitted a deprecation annotation.

## Jobs

**`lint`** — `gofmt -l` (with a diff on failure), `go mod tidy` drift check, `go vet`, and `golangci-lint`. The tidy check catches a `go.mod`/`go.sum` that a contributor forgot to regenerate, which is otherwise invisible until it breaks someone else's build.

**`test`** — matrix over ubuntu / macos / windows. `go build ./...`, then `go test -race -shuffle=on -coverprofile`. Race matters because the generator's e2e tests spawn nested `go test` runs; shuffle catches order-dependent tests. Coverage is summarized into the job summary and uploaded as an artifact (no third-party service, no token).

**`vulncheck`** — `govulncheck ./...`.

**`codeql`** — `security-and-quality` queries on PRs, pushes to `canary`, and weekly, so newly published queries reach code that has already merged.

## Two decisions worth flagging

**`govulncheck` runs on `stable`, not `go.mod`'s version.** `govulncheck` reports standard-library advisories against the toolchain it runs with. The `go` directive (`1.25.5`) declares the *minimum* release this module supports, not the one to build with — pinning the scan to it would report every stdlib CVE fixed since, permanently red, for something no change to this repo can address. Scanning with the current toolchain reports what a fresh `go install` actually produces.

Worth knowing what this does *not* cover: a user building with an older toolchain gets that toolchain's stdlib. That's inherent to `go install` and not fixable from CI.

**The open Dependabot alert is not reachable.** `github.com/buger/jsonparser` (DoS) comes in transitively via `libopenapi`. `govulncheck`'s call-graph analysis confirms this repo doesn't reach the vulnerable code — it's in the "modules you require, but your code doesn't appear to call" bucket. The added `dependabot.yml` (weekly, grouped, `chore(deps)` prefix so release-please classifies the commits) will pick up the fix when upstream ships it.

## `.golangci.yml`

Starts conservative: the `standard` set (errcheck, govet, ineffassign, staticcheck, unused) plus `misspell` and `usetesting`, with `errcheck` relaxed in `_test.go`. Deliberately not a maximal linter set — a lint gate that lands with hundreds of pre-existing findings gets ignored or disabled. Easy to widen once it's green and habitual.

## Still needed (org-level, outside this PR)

The `parallelworks` ruleset on the default branch requires 2 approvals and linear history but sets **no `required_status_checks`**. Until `ci / lint` and `ci / test` are marked required, a red run still won't block a merge — which is the difference between having CI and being protected by it.

## Verification

`gofmt`, `go vet`, `go mod tidy` drift, and `go test -race -shuffle=on ./...` all pass locally. The remaining jobs — golangci-lint, the macOS/Windows matrix legs, govulncheck, and CodeQL — are verified by this PR's own run.

---

## What the new jobs caught on their first run

The pipeline found three real defects immediately, all fixed in the second commit here.

**1. Two unchecked errors (`errcheck`, `cmd/generate.go`).** `generateCmd.MarkFlagRequired("spec")` and `("out")` discarded their returns. `init` can't return, so the errors are now joined into a package-level `setupErr` that `Execute` reports before running anything — no `panic`, per the repo's Go standards. Verified `generate` with no flags still errors with `required flag(s) "out", "spec" not set`.

**2. A genuine Windows bug in the generator, not just a test failure.** `TestGenerate_EmbeddedFields` failed on `windows-latest`. Cause: git checks templates out with CRLF on Windows, and the generator writes template bytes verbatim through `text/template` — so a Windows clone emitted **CRLF in every generated `.go` file**. Fixed at the root with `.gitattributes` (`* text=auto eol=lf`) rather than by loosening the assertion. This only affects building from a source checkout; `go install` pulls LF bytes from the module proxy.

**3. The Windows test step never even started.** The runner defaults to PowerShell, which split `-coverprofile=coverage.out` into two arguments, leaving `go test` looking for a package named `.out`. The workflow now pins `defaults.run.shell: bash` across the matrix.

Worth noting the second one is exactly the class of bug the old single-OS pipeline could never have surfaced.

## Final status

All seven checks pass: `lint`, `test (ubuntu-latest)`, `test (macos-latest)`, `test (windows-latest)`, `vulncheck`, `analyze`, `CodeQL`. CodeQL's `security-and-quality` suite reported no findings.
