### PR TITLE
fix(analyzer): a security scheme the generator cannot use costs the whole client

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -68,6 +69,10 @@ func generate(specPath, outputDir, packageName, userAgent string, allowRemoteRef
 		return fmt.Errorf("analyzing spec: %w", err)
 	}
 	pkg.UserAgent = userAgent
+
+	for _, w := range pkg.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
 
 	gen, err := generator.New(pkg)
 	if err != nil {

--- a/internal/analyzer/security.go
+++ b/internal/analyzer/security.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"fmt"
+	"strings"
 
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 
@@ -30,14 +31,17 @@ func (a *Analyzer) analyzeSecuritySchemes(pkg *ir.Package) error {
 
 		switch scheme.Type {
 		case "http":
-			switch scheme.Scheme {
+			// RFC 7235 registers auth scheme names case-insensitively, and specs
+			// spell this one both ways.
+			switch strings.ToLower(scheme.Scheme) {
 			case "bearer":
 				authScheme.Type = ir.AuthTypeBearer
 				authScheme.BearerFormat = scheme.BearerFormat
 			case "basic":
 				authScheme.Type = ir.AuthTypeBasic
 			default:
-				return fmt.Errorf("unsupported http scheme %q for security scheme %q", scheme.Scheme, schemeName)
+				pkg.Warnings = append(pkg.Warnings, fmt.Sprintf("security scheme %q: no provider generated for http scheme %q", schemeName, scheme.Scheme))
+				continue
 			}
 
 		case "apiKey":
@@ -51,8 +55,20 @@ func (a *Analyzer) analyzeSecuritySchemes(pkg *ir.Package) error {
 				authScheme.OAuthFlows = convertOAuthFlows(scheme.Flows)
 			}
 
+		case "openIdConnect":
+			// OpenID Connect is a bearer token on the wire; the discovery document
+			// is the caller's business, not the transport's.
+			authScheme.Type = ir.AuthTypeBearer
+
+		case "mutualTLS":
+			// The certificate is configured on the transport, so there is nothing
+			// for a provider to add to the request.
+			pkg.Warnings = append(pkg.Warnings, fmt.Sprintf("security scheme %q: mutualTLS is configured on the HTTP transport, so no provider is generated", schemeName))
+			continue
+
 		default:
-			return fmt.Errorf("unsupported security scheme type %q for %q", scheme.Type, schemeName)
+			pkg.Warnings = append(pkg.Warnings, fmt.Sprintf("security scheme %q: no provider generated for unrecognized type %q", schemeName, scheme.Type))
+			continue
 		}
 
 		pkg.AuthSchemes = append(pkg.AuthSchemes, authScheme)

--- a/internal/analyzer/security_test.go
+++ b/internal/analyzer/security_test.go
@@ -96,3 +96,56 @@ func TestAnalyzeSecuritySchemes_NilSecuritySchemes(t *testing.T) {
 
 	result.Model.Components.SecuritySchemes = origSchemes
 }
+
+const degradedSecuritySpec = `openapi: 3.1.0
+info: { title: sec, version: "1" }
+paths:
+  /t:
+    get:
+      operationId: getT
+      responses:
+        "204": { description: ok }
+components:
+  securitySchemes:
+    oidc:
+      type: openIdConnect
+      openIdConnectUrl: https://issuer.example.com/.well-known/openid-configuration
+    caps:
+      type: http
+      scheme: Bearer
+    legacy:
+      type: http
+      scheme: digest
+    mtls:
+      type: mutualTLS
+    weird:
+      type: somethingNew
+`
+
+// A scheme the generator cannot act on is one declaration in a spec the caller
+// may not even authenticate with, so it costs a warning rather than the client.
+func TestSecuritySchemes_UnsupportedDegradeToAWarning(t *testing.T) {
+	pkg, _ := analyzeSpec(t, degradedSecuritySpec)
+
+	byName := make(map[string]*ir.AuthScheme, len(pkg.AuthSchemes))
+	for _, s := range pkg.AuthSchemes {
+		byName[s.Name] = s
+	}
+
+	// OpenID Connect is a bearer token on the wire.
+	if oidc := byName["oidc"]; oidc == nil || oidc.Type != ir.AuthTypeBearer {
+		t.Errorf("oidc scheme = %+v, want a bearer provider", oidc)
+	}
+	// RFC 7235 makes the scheme name case-insensitive.
+	if caps := byName["caps"]; caps == nil || caps.Type != ir.AuthTypeBearer {
+		t.Errorf("caps scheme = %+v, want a bearer provider", caps)
+	}
+	for _, name := range []string{"legacy", "mtls", "weird"} {
+		if s := byName[name]; s != nil {
+			t.Errorf("%s scheme = %+v, want no provider", name, s)
+		}
+	}
+	if len(pkg.Warnings) != 3 {
+		t.Errorf("warnings = %v, want one each for legacy, mtls, and weird", pkg.Warnings)
+	}
+}

--- a/internal/ir/package.go
+++ b/internal/ir/package.go
@@ -9,6 +9,7 @@ type Package struct {
 	ServerURLs  []string        // Default server URLs
 	Info        *APIInfo        // API title, version, description
 	UserAgent   string          // Default User-Agent for generated clients
+	Warnings    []string        // Spec constructs the generator could not act on
 }
 
 // APIInfo contains metadata about the API.


### PR DESCRIPTION
Closes #62.

Two shapes stopped generation entirely:

```
$ go run . generate --spec spec.yaml --out ./out
Error: analyzing spec: unsupported security scheme type "openIdConnect" for "oidc"
Error: analyzing spec: unsupported http scheme "Bearer" for security scheme "auth"
```

No client at all, over one declaration the caller may not even be authenticating with. Any API fronted by Keycloak, Auth0, or Entra declares OIDC, and `scheme: Bearer` with a capital B is equivalent to `bearer` under RFC 7235, which registers auth scheme names case-insensitively.

## Behavior now

| declaration | before | after |
|---|---|---|
| `type: openIdConnect` | generation fails | bearer provider |
| `scheme: Bearer` | generation fails | bearer provider |
| `type: mutualTLS` | generation fails | warning, no provider |
| `scheme: digest` | generation fails | warning, no provider |
| unrecognized `type` | generation fails | warning, no provider |

OpenID Connect is a bearer token on the wire; the discovery document is the caller's concern, not the transport's. mutualTLS is configured on the `http.Client`, so there is nothing for a provider to add to a request.

Unsupported schemes warn rather than pass silently, since a client with no provider for a scheme the API requires would otherwise look like it authenticates and 401:

```
warning: security scheme "legacy": no provider generated for http scheme "digest"
warning: security scheme "mtls": mutualTLS is configured on the HTTP transport, so no provider is generated
warning: security scheme "weird": no provider generated for unrecognized type "somethingNew"
```

Warnings collect on `ir.Package` and the CLI prints them to stderr, so the analyzer stays free of output concerns. That channel is reusable for anything else the generator has to skip.

I did not carry `openIdConnectUrl` into the IR. Nothing renders per-scheme metadata today, so it would be a field with no reader.

## Tests

`internal/analyzer/security_test.go` covers a spec declaring all five shapes at once: `openIdConnect` and `Bearer` produce bearer providers, `digest`, `mutualTLS`, and an unrecognized type produce no provider and one warning each, and analysis returns no error.

`gofmt`, `go vet ./...`, and `go test ./...` pass.