### PR TITLE
feat(generator): the client knows the server URL the spec declares

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Given any OpenAPI 3.1 (or 3.0) spec, it outputs a complete, idiomatic Go client 
 
 - **Typed models** — structs, enums, type aliases, and union types (allOf/oneOf/anyOf) with JSON marshaling
 - **Client methods** — per-operation methods with `context.Context`, typed parameters, and typed responses
+- **Server URLs**: `DefaultBaseURL` from the spec, with a builder for templated servers
 - **Response headers**: status and headers captured through the context, with declared headers parsed per operation
 - **Authentication** — `AuthProvider` interface with built-in Bearer, API key, and Basic auth
 - **Error handling** — `APIError` with sentinel errors (`errors.Is`), typed error wrappers with parsed response bodies (`errors.As`)
@@ -132,6 +133,35 @@ func main() {
 }
 ```
 
+### Server URLs
+
+When the spec declares a server, the generated package states it, so the URL does
+not have to be copied into the code:
+
+```go
+client := petstore.NewClient(petstore.DefaultBaseURL)
+```
+
+`DefaultBaseURL` is the first server the spec lists, with every template variable
+at its default. A templated server also gets a builder, one parameter per
+variable in the order the URL uses them, where an empty argument takes that
+variable's default:
+
+```yaml
+servers:
+  - url: https://{region}.api.example.com/{basePath}
+    variables:
+      region:   { default: us-east-1, enum: [us-east-1, eu-west-1] }
+      basePath: { default: v2 }
+```
+
+```go
+client := petstore.NewClient(petstore.ServerURL("eu-west-1", ""))
+// https://eu-west-1.api.example.com/v2
+```
+
+A relative server URL (`/api/v3`) gets neither, since it resolves against
+wherever the spec is served and the generated package cannot know that host.
 ### Response headers
 
 A method returns the decoded body, so what a response says outside its body is

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -55,12 +55,7 @@ func (a *Analyzer) Analyze(packageName string) (*ir.Package, error) {
 		}
 	}
 
-	// Extract server URLs.
-	for _, server := range a.model.Servers {
-		if server != nil {
-			pkg.ServerURLs = append(pkg.ServerURLs, server.URL)
-		}
-	}
+	pkg.Servers = a.convertServers()
 
 	// A multipart body's binary properties are generated as file parts rather
 	// than as byte slices, which has to be settled before the schemas holding

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -44,8 +44,8 @@ func TestAnalyzePetstore(t *testing.T) {
 	if pkg.Info.Version != "1.0.0" {
 		t.Errorf("pkg.Info.Version = %q, want %q", pkg.Info.Version, "1.0.0")
 	}
-	if len(pkg.ServerURLs) != 1 || pkg.ServerURLs[0] != "https://petstore.example.com/v1" {
-		t.Errorf("pkg.ServerURLs = %v, want [https://petstore.example.com/v1]", pkg.ServerURLs)
+	if len(pkg.Servers) != 1 || pkg.Servers[0].URL != "https://petstore.example.com/v1" {
+		t.Errorf("pkg.Servers = %v, want one server at https://petstore.example.com/v1", pkg.Servers)
 	}
 
 	if len(pkg.Types) == 0 {

--- a/internal/analyzer/servers.go
+++ b/internal/analyzer/servers.go
@@ -1,0 +1,66 @@
+package analyzer
+
+import (
+	"regexp"
+	"strconv"
+
+	naming "github.com/giraffesyo/openapi-go-naming"
+
+	"github.com/parallelworks/openapi-client-generator/internal/ir"
+)
+
+// serverTemplateVar matches one {variable} placeholder of a server URL.
+var serverTemplateVar = regexp.MustCompile(`\{([^{}]+)\}`)
+
+// convertServers lowers the spec's servers list, pairing each URL with the
+// variables it interpolates.
+func (a *Analyzer) convertServers() []*ir.ServerDef {
+	var servers []*ir.ServerDef
+	for _, server := range a.model.Servers {
+		if server == nil || server.URL == "" {
+			continue
+		}
+		sd := &ir.ServerDef{
+			URL:         server.URL,
+			Description: server.Description,
+		}
+		// The URL drives the order, so the generated parameters read left to
+		// right the way the URL does.
+		seen := map[string]bool{}
+		goNames := map[string]bool{}
+		for _, match := range serverTemplateVar.FindAllStringSubmatch(server.URL, -1) {
+			name := match[1]
+			// One substitution covers every occurrence, so a variable used twice
+			// still takes one parameter.
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			sv := &ir.ServerVar{
+				Name:   name,
+				GoName: uniqueGoName(goNames, naming.Unexported(name)),
+			}
+			if server.Variables != nil {
+				if declared, ok := server.Variables.Get(name); ok && declared != nil {
+					sv.Default = declared.Default
+					sv.Enum = declared.Enum
+					sv.Description = declared.Description
+				}
+			}
+			sd.Variables = append(sd.Variables, sv)
+		}
+		servers = append(servers, sd)
+	}
+	return servers
+}
+
+// uniqueGoName keeps two variables that normalize to one Go identifier from
+// declaring the same parameter twice.
+func uniqueGoName(taken map[string]bool, name string) string {
+	candidate := name
+	for i := 2; taken[candidate]; i++ {
+		candidate = name + strconv.Itoa(i)
+	}
+	taken[candidate] = true
+	return candidate
+}

--- a/internal/analyzer/servers_test.go
+++ b/internal/analyzer/servers_test.go
@@ -1,0 +1,67 @@
+package analyzer
+
+import "testing"
+
+const templatedServerSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+servers:
+  - url: https://{region}.api.example.com/{base_path}/{region}
+    description: regional
+    variables:
+      region: { default: us-east-1, enum: [us-east-1, eu-west-1] }
+      base_path: { default: v2 }
+  - url: https://staging.api.example.com
+paths: {}
+`
+
+func TestServers_VariablesFollowTheURL(t *testing.T) {
+	pkg, _ := analyzeSpec(t, templatedServerSpec)
+
+	if len(pkg.Servers) != 2 {
+		t.Fatalf("servers = %d, want 2", len(pkg.Servers))
+	}
+	primary := pkg.Servers[0]
+	if len(primary.Variables) != 2 {
+		t.Fatalf("variables = %+v, want region and base_path once each", primary.Variables)
+	}
+	// A variable used twice still takes one parameter, and the URL sets the order.
+	if primary.Variables[0].Name != "region" || primary.Variables[1].Name != "base_path" {
+		t.Errorf("variable order = %q, %q, want region then base_path", primary.Variables[0].Name, primary.Variables[1].Name)
+	}
+	if primary.Variables[1].GoName != "basePath" {
+		t.Errorf("base_path GoName = %q, want basePath", primary.Variables[1].GoName)
+	}
+	if primary.Variables[0].Default != "us-east-1" || len(primary.Variables[0].Enum) != 2 {
+		t.Errorf("region = %+v, want its default and enum carried", primary.Variables[0])
+	}
+	if len(pkg.Servers[1].Variables) != 0 {
+		t.Errorf("staging server variables = %+v, want none", pkg.Servers[1].Variables)
+	}
+}
+
+const collidingServerVarSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+servers:
+  - url: https://example.com/{base_path}/{basePath}/{type}
+paths: {}
+`
+
+// Two variables can normalize to one Go identifier, and a variable can be named
+// for a keyword. Either one declares a parameter the compiler rejects.
+func TestServers_VariableNamesStayValidGo(t *testing.T) {
+	pkg, _ := analyzeSpec(t, collidingServerVarSpec)
+
+	var names []string
+	for _, v := range pkg.Servers[0].Variables {
+		names = append(names, v.GoName)
+	}
+	want := []string{"basePath", "basePath2", "type_"}
+	if len(names) != len(want) {
+		t.Fatalf("parameter names = %v, want %v", names, want)
+	}
+	for i, w := range want {
+		if names[i] != w {
+			t.Errorf("parameter %d = %q, want %q", i, names[i], w)
+		}
+	}
+}

--- a/internal/generator/e2e_server_test.go
+++ b/internal/generator/e2e_server_test.go
@@ -1,0 +1,103 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+)
+
+const templatedServerAPISpec = `openapi: 3.1.0
+info: { title: regional, version: "1" }
+servers:
+  - url: https://{region}.api.example.com/{basePath}
+    variables:
+      region: { default: us-east-1, enum: [us-east-1, eu-west-1] }
+      basePath: { default: v2 }
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: array, items: { type: string } }
+`
+
+// TestE2E_ServerURLFromSpec covers the URL the spec states: a caller should not
+// have to paste it, and a templated one is unusable until its variables are
+// substituted.
+func TestE2E_ServerURLFromSpec(t *testing.T) {
+	files, _ := generateFromSpec(t, templatedServerAPISpec, "regional")
+
+	runGeneratedWireTest(t, files, "serverurl", `package regional
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDefaultBaseURLTakesTheVariableDefaults(t *testing.T) {
+	if DefaultBaseURL != "https://us-east-1.api.example.com/v2" {
+		t.Errorf("DefaultBaseURL = %q, want the declared URL with its defaults", DefaultBaseURL)
+	}
+}
+
+func TestServerURLSubstitutes(t *testing.T) {
+	if got := ServerURL("eu-west-1", "v3"); got != "https://eu-west-1.api.example.com/v3" {
+		t.Errorf("ServerURL = %q", got)
+	}
+	if got := ServerURL("", ""); got != DefaultBaseURL {
+		t.Errorf("ServerURL with empty arguments = %q, want %q", got, DefaultBaseURL)
+	}
+	if got := ServerURL("eu-west-1", ""); got != "https://eu-west-1.api.example.com/v2" {
+		t.Errorf("ServerURL with one argument = %q", got)
+	}
+}
+
+// The built URL has to work as a base URL, not just read like one.
+func TestBuiltURLDrivesTheClient(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		json.NewEncoder(w).Encode([]string{"a"})
+	}))
+	defer srv.Close()
+
+	base := strings.Replace(ServerURL("eu-west-1", "v3"), "https://eu-west-1.api.example.com", srv.URL, 1)
+	things, err := NewClient(base).ListThings(t.Context())
+	if err != nil {
+		t.Fatalf("ListThings: %v", err)
+	}
+	if gotPath != "/v3/things" {
+		t.Errorf("requested %q, want the server path joined to the operation path", gotPath)
+	}
+	if things == nil || len((*things)) != 1 {
+		t.Errorf("things = %v, want one item", things)
+	}
+}
+`)
+}
+
+const relativeServerSpec = `openapi: 3.1.0
+info: { title: rel, version: "1" }
+servers:
+  - url: /api/v3
+paths: {}
+`
+
+// A relative server URL is resolved against wherever the spec is served, so
+// there is no constant that stands in for it.
+func TestE2E_RelativeServerHasNoDefaultBaseURL(t *testing.T) {
+	files, _ := generateFromSpec(t, relativeServerSpec, "relapi")
+
+	for _, f := range files {
+		if f.Name == "client.go" && strings.Contains(string(f.Content), "DefaultBaseURL") {
+			t.Error("a relative server URL produced a DefaultBaseURL constant")
+		}
+	}
+	buildGenerated(t, files, "relserver")
+}

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -55,6 +55,8 @@ func FuncMap() template.FuncMap {
 		"successContentType":      successContentType,
 		"requestContentType":      requestContentType,
 		"hasNonJSONBody":          hasNonJSONBody,
+		"primaryServer":           primaryServer,
+		"defaultBaseURL":          defaultBaseURL,
 		"operationHeaders":        operationHeaders,
 		"headerKinds":             headerKinds,
 		"headerDocComment":        headerDocComment,
@@ -588,6 +590,37 @@ func unionBaseFields(pkg *ir.Package, td *ir.TypeDef) []*ir.Field {
 		return nil
 	}
 	return base.Fields
+}
+
+// primaryServer returns the server the spec presents first, which is the one the
+// generated client defaults to. It returns nil when the spec declares none.
+func primaryServer(pkg *ir.Package) *ir.ServerDef {
+	if len(pkg.Servers) == 0 {
+		return nil
+	}
+	return pkg.Servers[0]
+}
+
+// defaultBaseURL returns the primary server's URL with every template variable
+// at its default, or "" when a variable has no default to substitute.
+func defaultBaseURL(pkg *ir.Package) string {
+	server := primaryServer(pkg)
+	if server == nil {
+		return ""
+	}
+	// A relative server URL is resolved against wherever the spec is served, which
+	// a generated constant cannot stand in for.
+	url := server.URL
+	if !strings.Contains(url, "://") {
+		return ""
+	}
+	for _, v := range server.Variables {
+		if v.Default == "" {
+			return ""
+		}
+		url = strings.ReplaceAll(url, "{"+v.Name+"}", v.Default)
+	}
+	return url
 }
 
 // operationHeaders returns the headers an operation declares across all of its

--- a/internal/ir/package.go
+++ b/internal/ir/package.go
@@ -6,10 +6,26 @@ type Package struct {
 	Types       []*TypeDef      // All type definitions
 	Operations  []*OperationDef // All API operations
 	AuthSchemes []*AuthScheme   // Security schemes from the spec
-	ServerURLs  []string        // Default server URLs
+	Servers     []*ServerDef    // Servers the spec declares, in spec order
 	Info        *APIInfo        // API title, version, description
 	UserAgent   string          // Default User-Agent for generated clients
 	Warnings    []string        // Spec constructs the generator could not act on
+}
+
+// ServerDef is one entry of the spec's servers list.
+type ServerDef struct {
+	URL         string
+	Description string
+	Variables   []*ServerVar // Template variables, in the order they appear in URL
+}
+
+// ServerVar is one template variable of a server URL.
+type ServerVar struct {
+	Name        string // Name as it appears in the URL template
+	GoName      string // Go parameter name
+	Default     string
+	Enum        []string
+	Description string
 }
 
 // APIInfo contains metadata about the API.

--- a/internal/templates/client.go.tmpl
+++ b/internal/templates/client.go.tmpl
@@ -13,6 +13,31 @@ import (
 	"time"
 )
 
+{{- with defaultBaseURL $ }}
+// DefaultBaseURL is the server this API declares first, with every template
+// variable at its default value.
+const DefaultBaseURL = {{ printf "%q" . }}
+{{ end }}
+{{- with primaryServer $ }}{{ if .Variables }}
+// ServerURL builds the URL of the server this API declares first, substituting
+// its template variables. An empty argument takes that variable's default.
+{{- range .Variables }}
+//
+// {{ .Name }}{{ if .Default }} defaults to {{ .Default }}{{ end }}{{ if .Enum }}, one of: {{ range $i, $e := .Enum }}{{ if $i }}, {{ end }}{{ $e }}{{ end }}{{ end }}.
+{{- end }}
+func ServerURL({{ range $i, $v := .Variables }}{{ if $i }}, {{ end }}{{ $v.GoName }} string{{ end }}) string {
+	url := {{ printf "%q" .URL }}
+{{- range .Variables }}
+{{- if .Default }}
+	if {{ .GoName }} == "" {
+		{{ .GoName }} = {{ printf "%q" .Default }}
+	}
+{{- end }}
+	url = strings.ReplaceAll(url, {{ printf "%q" (printf "{%s}" .Name) }}, {{ .GoName }})
+{{- end }}
+	return url
+}
+{{ end }}{{ end }}
 // Client is an API client for {{ if .Info }}{{ .Info.Title }}{{ else }}the service{{ end }}.
 type Client struct {
 	baseURL     string


### PR DESCRIPTION
Closes #71.

`servers` was parsed into `pkg.ServerURLs` and read by nothing, so the one fact a spec is most certain about, where the API lives, was the one thing the generated package did not know. Every caller pasted it back in:

```go
client := petstore.NewClient("https://api.example.com/v2")   // straight out of the spec
```

And a templated server URL had no substitution at all, so pasting it produced a client requesting `https://{region}.api.example.com/...`.

## What is generated

```go
// DefaultBaseURL is the server this API declares first, with every template
// variable at its default value.
const DefaultBaseURL = "https://us-east-1.api.example.com/v2"

// ServerURL builds the URL of the server this API declares first, substituting
// its template variables. An empty argument takes that variable's default.
//
// region defaults to us-east-1, one of: us-east-1, eu-west-1.
//
// basePath defaults to v2.
func ServerURL(region string, basePath string) string
```

```go
client := petstore.NewClient(petstore.DefaultBaseURL)
client := petstore.NewClient(petstore.ServerURL("eu-west-1", ""))
```

`NewClient` is untouched, so nothing existing changes. `ServerURL` is generated only when the first server is templated.

## Decisions

- **First server only.** Naming a constant per server needs names the spec does not provide, and `description` is free text. The first is the one the spec presents as primary.
- **A relative server URL gets neither.** `/api/v3` resolves against wherever the spec is served, so a constant would produce a client that requests a relative URL and fails.
- **A variable with no default gets no `DefaultBaseURL`**, since there is nothing to substitute, but `ServerURL` is still generated so the caller can supply it.
- **Parameters follow the URL**, not the `variables` map, so they read left to right the way the URL does. A variable used twice takes one parameter, since one substitution covers every occurrence.

`ir.Package.ServerURLs` becomes `Servers []*ServerDef`, which carries each server's variables, defaults, and enums.

## Tests

- `internal/analyzer/servers_test.go`: variables follow the URL and a repeat takes one parameter; defaults and enums are carried; names stay valid Go, covering two variables that normalize to one identifier (`base_path` and `basePath`) and one named for a keyword (`type`).
- `internal/generator/e2e_server_test.go`: compiles and runs the generated package, checking `DefaultBaseURL`, substitution with both, one, and no arguments, and then drives a real request through `httptest` to confirm the built URL works as a base URL rather than only reading like one. A relative server produces no constant and still compiles.

`gofmt`, `go vet ./...`, and `go test ./...` pass.