### PR TITLE
feat(analyzer): an object written inline keeps the properties it declares

### DIFF
--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -800,6 +800,9 @@ func TestComplexSchemas_AllTypesPresent(t *testing.T) {
 		// Circle and Rectangle both declare shapeType, and the body union
 		// dispatches on kind, so the shared property becomes a base.
 		"CreateShapeBodyBase",
+		// StringOrInt's two members are objects written inline, each of which
+		// declares a property and so names a struct.
+		"StringOrIntVariant", "StringOrIntVariant2",
 	}
 
 	if len(pkg.Types) != len(expectedTypes) {

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -581,9 +581,12 @@ func (a *Analyzer) resolveGoType(schema *highbase.Schema, nameHint string) strin
 			}
 			return "map[string]any"
 		}
-		// Complex inline object -- for now use any. Full support would create
-		// an anonymous struct or a named type.
-		return "any"
+		if name, ok := a.synthesizeInlineObject(schema, nameHint); ok {
+			return name
+		}
+		// With no hint there is no name to declare the struct under, so the
+		// properties are reachable only as map keys.
+		return "map[string]any"
 	case "array":
 		elemType := "any"
 		if schema.Items != nil && schema.Items.IsA() {
@@ -666,6 +669,61 @@ func (a *Analyzer) synthesizeInlineUnion(schema *highbase.Schema, nameHint strin
 	a.synthesizedByKey[key] = td
 	a.synthesized = append(a.synthesized, td)
 	return goName, true
+}
+
+// synthesizeInlineObject declares a named struct for an object written inline, so
+// the properties it lists stay typed instead of collapsing into any. Two
+// declarations of one shape share a type.
+func (a *Analyzer) synthesizeInlineObject(schema *highbase.Schema, nameHint string) (string, bool) {
+	// A titled schema names itself, which keeps the generated name stable when
+	// the property that reaches it first is renamed.
+	if schema.Title != "" {
+		nameHint = schema.Title
+	}
+	if nameHint == "" {
+		return "", false
+	}
+
+	key := a.inlineObjectKey(schema, nameHint)
+	if existing, ok := a.synthesizedByKey[key]; ok {
+		return existing.Name, true
+	}
+
+	goName := a.namer.Unique(naming.Exported(nameHint))
+	td, err := a.convertObject(goName, schema, false, false)
+	if err != nil || td == nil {
+		return "", false
+	}
+	a.synthesizedByKey[key] = td
+	a.synthesized = append(a.synthesized, td)
+	return goName, true
+}
+
+// inlineObjectKey identifies an inline object by the Go it would generate, so two
+// properties declaring the same shape land on one type rather than two names for
+// it.
+func (a *Analyzer) inlineObjectKey(schema *highbase.Schema, nameHint string) string {
+	required := make(map[string]bool, len(schema.Required))
+	for _, r := range schema.Required {
+		required[r] = true
+	}
+
+	var b strings.Builder
+	b.WriteString("object")
+	for propName, propProxy := range schema.Properties.FromOldest() {
+		propSchema, err := propProxy.BuildSchema()
+		if err != nil || propSchema == nil {
+			continue
+		}
+		b.WriteString("|" + propName + ":" + a.resolveGoType(propSchema, nameHint+naming.Exported(propName)))
+		if required[propName] {
+			b.WriteString(":required")
+		}
+	}
+	if allowsAdditionalProperties(schema) {
+		b.WriteString("|additional:" + a.resolveAdditionalPropertiesType(schema, nameHint))
+	}
+	return b.String()
 }
 
 // suffixHint appends a suffix to a naming hint, preserving emptiness so that

--- a/internal/analyzer/schemas_inline_object_test.go
+++ b/internal/analyzer/schemas_inline_object_test.go
@@ -1,0 +1,127 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/parallelworks/openapi-client-generator/internal/ir"
+)
+
+const inlineObjectSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Outer:
+      type: object
+      properties:
+        inner:
+          type: object
+          properties:
+            a: { type: string }
+            deeper:
+              type: object
+              properties:
+                b: { type: integer }
+          required: [a]
+        tags:
+          type: array
+          items:
+            type: object
+            properties:
+              name: { type: string }
+        same:
+          type: object
+          properties:
+            a: { type: string }
+            deeper:
+              type: object
+              properties:
+                b: { type: integer }
+          required: [a]
+        titled:
+          type: object
+          title: Marker
+          properties:
+            id: { type: string }
+        bag:
+          type: object
+          additionalProperties: { type: string }
+`
+
+func TestInlineObject_PropertiesStayTyped(t *testing.T) {
+	_, typeMap := analyzeSpec(t, inlineObjectSpec)
+
+	outer := typeMap["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not found")
+	}
+	byJSON := make(map[string]*ir.Field, len(outer.Fields))
+	for _, f := range outer.Fields {
+		byJSON[f.JSONName] = f
+	}
+
+	if got := byJSON["inner"].Type; got != "*OuterInner" {
+		t.Errorf("inner type = %q, want *OuterInner", got)
+	}
+	if got := byJSON["tags"].Type; got != "[]OuterTagsItem" {
+		t.Errorf("tags type = %q, want []OuterTagsItem", got)
+	}
+	// An object with no properties still has nothing to declare fields from.
+	if got := byJSON["bag"].Type; got != "map[string]string" {
+		t.Errorf("bag type = %q, want map[string]string", got)
+	}
+
+	inner := typeMap["OuterInner"]
+	if inner == nil {
+		t.Fatal("OuterInner not synthesized")
+	}
+	if len(inner.Fields) != 2 {
+		t.Fatalf("OuterInner fields = %+v, want a and deeper", inner.Fields)
+	}
+	if inner.Fields[0].Type != "string" || !inner.Fields[0].Required {
+		t.Errorf("OuterInner.A = %+v, want a required string", inner.Fields[0])
+	}
+	// Nesting keeps going: the object inside the object is named too.
+	if inner.Fields[1].Type != "*OuterInnerDeeper" {
+		t.Errorf("OuterInner.Deeper = %q, want *OuterInnerDeeper", inner.Fields[1].Type)
+	}
+	if typeMap["OuterInnerDeeper"] == nil {
+		t.Error("OuterInnerDeeper not synthesized")
+	}
+}
+
+// Two properties declaring one shape share a type rather than generating a
+// duplicate under each property's name.
+func TestInlineObject_IdenticalShapesShareAType(t *testing.T) {
+	_, typeMap := analyzeSpec(t, inlineObjectSpec)
+
+	outer := typeMap["Outer"]
+	var inner, same string
+	for _, f := range outer.Fields {
+		switch f.JSONName {
+		case "inner":
+			inner = f.Type
+		case "same":
+			same = f.Type
+		}
+	}
+	if inner != same {
+		t.Errorf("inner = %q and same = %q, want one type for one shape", inner, same)
+	}
+	if typeMap["OuterSame"] != nil {
+		t.Error("a second type was generated for a shape that already had one")
+	}
+}
+
+// A titled schema names itself, so renaming the property that reaches it first
+// does not rename the generated type.
+func TestInlineObject_TitleNamesTheType(t *testing.T) {
+	_, typeMap := analyzeSpec(t, inlineObjectSpec)
+
+	if typeMap["Marker"] == nil {
+		t.Error("a titled inline object should be named for its title")
+	}
+	if typeMap["OuterTitled"] != nil {
+		t.Error("the title was ignored in favor of the property name")
+	}
+}

--- a/internal/generator/e2e_inline_object_test.go
+++ b/internal/generator/e2e_inline_object_test.go
@@ -1,0 +1,124 @@
+package generator
+
+import "testing"
+
+const inlineObjectAPISpec = `openapi: 3.1.0
+info: { title: orders, version: "1" }
+paths:
+  /orders:
+    post:
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Order" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Order" }
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id: { type: string }
+        customer:
+          type: object
+          properties:
+            name: { type: string }
+            address:
+              type: object
+              properties:
+                city: { type: string }
+              required: [city]
+          required: [name]
+        lines:
+          type: array
+          items:
+            type: object
+            properties:
+              sku: { type: string }
+              qty: { type: integer }
+            required: [sku, qty]
+      required: [id, customer]
+`
+
+// TestE2E_InlineObjectsAreConstructible covers a nested object written inline,
+// which resolved to any: the properties it declares were unreadable without a
+// type assertion and unwritable without building a map by hand.
+func TestE2E_InlineObjectsAreConstructible(t *testing.T) {
+	files, _ := generateFromSpec(t, inlineObjectAPISpec, "ordersapi")
+
+	runGeneratedWireTest(t, files, "inlineobject", `package ordersapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The value has to be constructible in Go, which a map behind an any is not.
+func TestConstructAndSend(t *testing.T) {
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.Write(got)
+	}))
+	defer srv.Close()
+
+	order := Order{
+		ID: "o-1",
+		Customer: OrderCustomer{
+			Name:    "Ada",
+			Address: &OrderCustomerAddress{City: "London"},
+		},
+		Lines: []OrderLinesItem{{Sku: "abc", Qty: 2}},
+	}
+
+	back, err := NewClient(srv.URL).CreateOrder(t.Context(), order)
+	if err != nil {
+		t.Fatalf("CreateOrder: %v", err)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(got, &sent); err != nil {
+		t.Fatalf("request body: %v", err)
+	}
+	customer, ok := sent["customer"].(map[string]any)
+	if !ok || customer["name"] != "Ada" {
+		t.Errorf("customer on the wire = %#v", sent["customer"])
+	}
+	if addr, ok := customer["address"].(map[string]any); !ok || addr["city"] != "London" {
+		t.Errorf("address on the wire = %#v", customer["address"])
+	}
+
+	// And the same shape decodes back into the same types.
+	if back.Customer.Address == nil || back.Customer.Address.City != "London" {
+		t.Errorf("decoded address = %+v", back.Customer.Address)
+	}
+	if len(back.Lines) != 1 || back.Lines[0].Sku != "abc" || back.Lines[0].Qty != 2 {
+		t.Errorf("decoded lines = %+v", back.Lines)
+	}
+}
+
+// An optional inline object is a pointer, so absent stays distinguishable from
+// present-and-empty.
+func TestAbsentInlineObjectIsNil(t *testing.T) {
+	var o Order
+	if err := json.Unmarshal([]byte(`+"`"+`{"id":"o-2","customer":{"name":"Bo"}}`+"`"+`), &o); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if o.Customer.Address != nil {
+		t.Errorf("Address = %+v, want nil", o.Customer.Address)
+	}
+	if o.Customer.Name != "Bo" {
+		t.Errorf("Name = %q, want Bo", o.Customer.Name)
+	}
+}
+`)
+}

--- a/internal/generator/e2e_inline_union_test.go
+++ b/internal/generator/e2e_inline_union_test.go
@@ -218,6 +218,7 @@ components:
         - type: object
           properties:
             q: { type: string }
+        - description: anything at all
 `
 
 // TestE2E_UntypedUnionVariantStillDecodes covers a union member the analyzer
@@ -232,14 +233,30 @@ import (
 	"testing"
 )
 
-func TestUntypedVariantDecodes(t *testing.T) {
+func TestInlineObjectVariantIsTyped(t *testing.T) {
 	var m Mixed
 	if err := json.Unmarshal([]byte(`+"`"+`{"q":"x"}`+"`"+`), &m); err != nil {
 		t.Fatalf("a payload matching the inline object variant failed to decode: %v", err)
 	}
-	obj, ok := m.Value.(map[string]any)
-	if !ok || obj["q"] != "x" {
-		t.Errorf("Value = %#v, want the decoded object", m.Value)
+	obj, ok := m.Value.(MixedVariant)
+	if !ok {
+		t.Fatalf("Value = %#v, want the named struct the inline variant declares", m.Value)
+	}
+	if obj.Q == nil || *obj.Q != "x" {
+		t.Errorf("Q = %v, want x", obj.Q)
+	}
+}
+
+// A variant that declares nothing has no Go type of its own, and the payloads it
+// covers still have to decode.
+func TestUntypedVariantDecodes(t *testing.T) {
+	var m Mixed
+	if err := json.Unmarshal([]byte(`+"`"+`[1,2,3]`+"`"+`), &m); err != nil {
+		t.Fatalf("a payload matching only the untyped variant failed to decode: %v", err)
+	}
+	items, ok := m.Value.([]any)
+	if !ok || len(items) != 3 {
+		t.Errorf("Value = %#v, want the decoded array", m.Value)
 	}
 }
 


### PR DESCRIPTION
Closes #74.

`resolveGoType` returned `any` for any object declared inline. The placeholder said so:

```go
// Complex inline object -- for now use any. Full support would create
// an anonymous struct or a named type.
return "any"
```

```go
type Outer struct {
	Inner any   `json:"inner,omitempty"`   // before
	Tags  []any `json:"tags,omitempty"`
}
```

Every declared property was gone: unreadable without a type assertion and a map lookup, and unconstructible without building a map by hand.

## Now

```go
type Outer struct {
	Inner *OuterInner     `json:"inner,omitempty"`
	Tags  []OuterTagsItem `json:"tags,omitempty"`
}

type OuterInner struct {
	A string `json:"a"`
	B *int64 `json:"b,omitempty"`
}
```

Inline objects name a struct the way inline unions already do, reusing the name hints the call sites already thread through, and nesting keeps going: an object inside an inline object gets `OuterInnerDeeper`.

## Decisions

- **One shape, one type.** The key is what the shape generates in Go, so two properties declaring identical objects share a type rather than producing a duplicate under each property's name.
- **A title names the type.** A titled inline schema is named for its title, so renaming the property that reaches it first does not rename the generated type. This matches what inline unions already do.
- **No properties, no struct.** An object with only `additionalProperties` still resolves to a map, unchanged.
- **A hintless context resolves to `map[string]any`,** not `any`. There is no name to declare a struct under, and a map at least says the payload is an object.

## Two existing tests changed, both because the behavior improved

- `TestComplexSchemas_AllTypesPresent` now expects 20 types instead of 18. `StringOrInt`'s two members are objects written inline, so each now names a struct.
- `TestE2E_UntypedUnionVariantStillDecodes` asserted that an inline object union member decoded into `map[string]any`, which was the old degradation. It now asserts the member decodes into its named struct, and the spec gained a member that declares nothing at all so the genuinely untyped path stays covered.

## Tests

- `internal/analyzer/schemas_inline_object_test.go`: properties stay typed through two levels of nesting and through arrays, identical shapes share a type, a title names the type, and an object with only `additionalProperties` still maps.
- `internal/generator/e2e_inline_object_test.go`: compiles and runs a client that constructs the nested value in Go, sends it, checks what landed on the wire, decodes the response back into the same types, and confirms an absent optional inline object stays nil.

`gofmt`, `go vet ./...`, and `go test ./...` pass.