### PR TITLE
fix(analyzer): a parameter serialized with content went out style-encoded

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -34,6 +34,8 @@ type Analyzer struct {
 	prefixItemsSeen           bool
 	dependentSchemasSeen      bool
 	manyPatternPropertiesSeen bool
+	// warnings collects what the generator had to skip, for the CLI to report.
+	warnings []string
 }
 
 // New creates an Analyzer for the given high-level OpenAPI model.
@@ -90,6 +92,8 @@ func (a *Analyzer) Analyze(packageName string) (*ir.Package, error) {
 	if err := a.analyzeSecuritySchemes(pkg); err != nil {
 		return nil, err
 	}
+
+	pkg.Warnings = append(pkg.Warnings, a.warnings...)
 
 	if a.multiContentResponses > 0 {
 		noun := "responses offer"

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -232,7 +232,7 @@ func (a *Analyzer) convertOperation(httpMethod, path string, pathItem *v3high.Pa
 	// Operation-level params override path-level ones with the same name+location.
 	params := mergeParams(pathItem.Parameters, op.Parameters)
 	for _, param := range params {
-		pd, err := a.convertParam(param)
+		pd, err := a.convertParam(param, opDef.Name)
 		if err != nil {
 			return nil, fmt.Errorf("converting parameter %q: %w", param.Name, err)
 		}
@@ -374,15 +374,35 @@ func mergeParams(pathParams, opParams []*v3high.Parameter) []*v3high.Parameter {
 }
 
 // convertParam converts an OpenAPI parameter to an ir.ParamDef.
-func (a *Analyzer) convertParam(param *v3high.Parameter) (*ir.ParamDef, error) {
+func (a *Analyzer) convertParam(param *v3high.Parameter, opName string) (*ir.ParamDef, error) {
 	goType := "any"
-	if param.Schema != nil {
+	contentType := ""
+	switch {
+	case param.Schema != nil:
 		schema, err := param.Schema.BuildSchema()
 		if err != nil {
 			return nil, fmt.Errorf("building param schema: %w", err)
 		}
 		if schema != nil {
+			// No name hint: a style-encoded parameter is written into the URL by
+			// the query encoder, and a synthesized union or struct would go out
+			// as its Go shape rather than as the value the server parses.
 			goType = a.resolveGoType(schema, "")
+		}
+	case param.Content != nil:
+		// A parameter with content carries a document, and the media type says how
+		// to serialize it. Without reading it the value goes out style-encoded,
+		// which is not what the server parses.
+		var mediaType *v3high.MediaType
+		contentType, mediaType = preferredContent(param.Content)
+		if !isJSONContent(contentType) {
+			a.warnings = append(a.warnings, fmt.Sprintf("parameter %q: %s is not a media type this generator serializes, so the value is sent style-encoded", param.Name, contentType))
+		}
+		if mediaType != nil {
+			goType = a.resolveMediaTypeSchema(mediaType, opName+naming.Exported(param.Name))
+			if goType == "" {
+				goType = "any"
+			}
 		}
 	}
 
@@ -400,6 +420,7 @@ func (a *Analyzer) convertParam(param *v3high.Parameter) (*ir.ParamDef, error) {
 		Deprecated:  param.Deprecated,
 		Style:       style,
 		Explode:     explode,
+		ContentType: contentType,
 	}, nil
 }
 
@@ -590,6 +611,12 @@ func (a *Analyzer) convertSingleResponse(code string, resp *v3high.Response, nam
 	}
 
 	return rd
+}
+
+// isJSONContent reports whether a media type is one the generated code can
+// serialize a parameter value into.
+func isJSONContent(contentType string) bool {
+	return strings.Contains(contentType, "json")
 }
 
 // convertResponseHeaders lowers the headers a response declares. A header value

--- a/internal/analyzer/operations_test.go
+++ b/internal/analyzer/operations_test.go
@@ -534,3 +534,71 @@ func TestMultiMediaResponse_PrefersJSONAndSaysSo(t *testing.T) {
 		t.Errorf("media type warnings = %d, want 1: %v", found, pkg.Warnings)
 	}
 }
+
+const contentParamAnalyzerSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: filter
+          in: query
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Filter" }
+        - name: legacy
+          in: query
+          content:
+            application/xml:
+              schema: { type: string }
+        - name: plain
+          in: query
+          schema: { type: string }
+      responses:
+        "204": { description: ok }
+components:
+  schemas:
+    Filter:
+      type: object
+      properties:
+        field: { type: string }
+`
+
+// A parameter that names a media type carries a document, and the media type is
+// what says how to serialize it.
+func TestContentParam_CarriesItsMediaTypeAndSchema(t *testing.T) {
+	pkg, _ := analyzeSpec(t, contentParamAnalyzerSpec)
+
+	params := make(map[string]*ir.ParamDef)
+	for _, op := range pkg.Operations {
+		for _, p := range op.QueryParams {
+			params[p.OrigName] = p
+		}
+	}
+
+	filter := params["filter"]
+	if filter == nil {
+		t.Fatal("filter param not found")
+	}
+	if filter.ContentType != "application/json" {
+		t.Errorf("filter ContentType = %q, want application/json", filter.ContentType)
+	}
+	if filter.Type != "*Filter" && filter.Type != "Filter" {
+		t.Errorf("filter type = %q, want the declared schema rather than any", filter.Type)
+	}
+
+	// A media type the generator cannot serialize still types its value, and says
+	// so rather than sending JSON where the server expects something else.
+	if legacy := params["legacy"]; legacy == nil || legacy.ContentType != "application/xml" {
+		t.Errorf("legacy param = %+v, want its media type carried", legacy)
+	}
+	if len(pkg.Warnings) != 1 || !strings.Contains(pkg.Warnings[0], "legacy") {
+		t.Errorf("warnings = %v, want one naming the parameter that is not serialized", pkg.Warnings)
+	}
+
+	// A style-encoded parameter has no content type at all.
+	if plain := params["plain"]; plain == nil || plain.ContentType != "" {
+		t.Errorf("plain param = %+v, want no content type", plain)
+	}
+}

--- a/internal/generator/e2e_content_param_test.go
+++ b/internal/generator/e2e_content_param_test.go
@@ -1,0 +1,153 @@
+package generator
+
+import "testing"
+
+const contentParamSpec = `openapi: 3.1.0
+info: { title: search, version: "1" }
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: filter
+          in: query
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Filter" }
+        - name: X-Context
+          in: header
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Filter" }
+        - name: plain
+          in: query
+          schema: { type: string }
+        - name: inline
+          in: query
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  page: { type: integer }
+                required: [page]
+      responses:
+        "204": { description: ok }
+components:
+  schemas:
+    Filter:
+      type: object
+      properties:
+        field: { type: string }
+        values:
+          type: array
+          items: { type: string }
+      required: [field]
+`
+
+// TestE2E_ContentParamIsSerializedAsItsMediaType covers a parameter that names a
+// media type instead of a style. Its value is a document, and sending it
+// style-encoded is not what the server parses.
+func TestE2E_ContentParamIsSerializedAsItsMediaType(t *testing.T) {
+	files, _ := generateFromSpec(t, contentParamSpec, "searchapi")
+
+	runGeneratedWireTest(t, files, "contentparam", `package searchapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestJSONDocumentReachesTheServer(t *testing.T) {
+	var rawQuery, header string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawQuery = r.URL.Query().Get("filter")
+		header = r.Header.Get("X-Context")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	filter := Filter{Field: "name", Values: []string{"a", "b"}}
+	err := NewClient(srv.URL).ListItems(t.Context(), ListItemsParams{
+		Filter:   &filter,
+		XContext: &filter,
+	})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+
+	// The server decodes the parameter as the document it declared.
+	var got Filter
+	if err := json.Unmarshal([]byte(rawQuery), &got); err != nil {
+		t.Fatalf("query parameter was not the declared media type: %q: %v", rawQuery, err)
+	}
+	if got.Field != "name" || len(got.Values) != 2 {
+		t.Errorf("decoded filter = %+v, want the value that was sent", got)
+	}
+
+	var fromHeader Filter
+	if err := json.Unmarshal([]byte(header), &fromHeader); err != nil {
+		t.Fatalf("header parameter was not the declared media type: %q: %v", header, err)
+	}
+	if fromHeader.Field != "name" {
+		t.Errorf("decoded header filter = %+v", fromHeader)
+	}
+}
+
+// The schema behind a content parameter is typed like any other, including one
+// written inline.
+func TestInlineContentParamIsTyped(t *testing.T) {
+	var raw string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw = r.URL.Query().Get("inline")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	inline := ListItemsInline{Page: 3}
+	if err := NewClient(srv.URL).ListItems(t.Context(), ListItemsParams{Inline: &inline}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if raw != `+"`"+`{"page":3}`+"`"+` {
+		t.Errorf("inline = %q, want the serialized document", raw)
+	}
+}
+
+// A style-encoded parameter alongside it keeps its own encoding.
+func TestStyleParamIsUnaffected(t *testing.T) {
+	var plain string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		plain = r.URL.Query().Get("plain")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	value := "hello"
+	if err := NewClient(srv.URL).ListItems(t.Context(), ListItemsParams{Plain: &value}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if plain != "hello" {
+		t.Errorf("plain = %q, want hello unquoted", plain)
+	}
+}
+
+// An omitted optional parameter sends nothing, not "null".
+func TestAbsentContentParamIsOmitted(t *testing.T) {
+	var query string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := NewClient(srv.URL).ListItems(t.Context()); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if query != "" {
+		t.Errorf("query = %q, want no parameters at all", query)
+	}
+}
+`)
+}

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -60,6 +60,7 @@ func FuncMap() template.FuncMap {
 		"operationHeaders":        operationHeaders,
 		"inboundKinds":            inboundKinds,
 		"inboundPayloads":         inboundPayloads,
+		"serializedParam":         serializedParam,
 		"headerKinds":             headerKinds,
 		"headerDocComment":        headerDocComment,
 	}
@@ -658,6 +659,13 @@ func inboundPayloads(pkg *ir.Package, callback bool) []*ir.WebhookDef {
 		}
 	}
 	return defs
+
+}
+
+// serializedParam reports whether a parameter's value is written as a document in
+// the media type it declares, rather than encoded under an OpenAPI style.
+func serializedParam(p *ir.ParamDef) bool {
+	return strings.Contains(p.ContentType, "json")
 }
 
 // operationHeaders returns the headers an operation declares across all of its

--- a/internal/ir/operations.go
+++ b/internal/ir/operations.go
@@ -33,6 +33,7 @@ type ParamDef struct {
 	Deprecated  bool
 	Style       string // serialization style
 	Explode     bool
+	ContentType string // Media type when the parameter is serialized with content rather than a style
 }
 
 // RequestBodyDef describes the request body.

--- a/internal/templates/helpers.go.tmpl
+++ b/internal/templates/helpers.go.tmpl
@@ -379,6 +379,47 @@ func isRawResult(result any, body []byte) bool {
 	return false
 }
 
+// contentParamValue serializes a parameter declared with a media type rather than
+// a style. A nil optional pointer yields no value at all, which the callers skip.
+func contentParamValue(value any) (string, bool) {
+	rv, ok := derefParam(value)
+	if !ok {
+		return "", false
+	}
+	encoded, err := json.Marshal(rv.Interface())
+	if err != nil {
+		return "", false
+	}
+	return string(encoded), true
+}
+
+// addContentQueryParam adds a query parameter whose value is a serialized
+// document. The document goes in whole, percent-encoded by the query encoder.
+func addContentQueryParam(values url.Values, key string, value any) {
+	if encoded, ok := contentParamValue(value); ok {
+		values.Set(key, encoded)
+	}
+}
+
+// setContentHeader sets a header whose value is a serialized document.
+func setContentHeader(headers http.Header, name string, value any) {
+	if encoded, ok := contentParamValue(value); ok {
+		headers.Set(name, encoded)
+	}
+}
+
+// addContentCookieHeader appends a cookie whose value is a serialized document.
+func addContentCookieHeader(headers http.Header, name string, value any) {
+	if encoded, ok := contentParamValue(value); ok {
+		cookie := (&http.Cookie{Name: name, Value: encoded}).String()
+		if existing := headers.Get("Cookie"); existing != "" {
+			headers.Set("Cookie", existing+"; "+cookie)
+		} else {
+			headers.Set("Cookie", cookie)
+		}
+	}
+}
+
 // setHeader sets a header parameter (simple style), skipping a nil optional
 // pointer.
 func setHeader(headers http.Header, name string, explode bool, value any) {

--- a/internal/templates/operations.go.tmpl
+++ b/internal/templates/operations.go.tmpl
@@ -34,14 +34,19 @@ type {{ .Name }}Params struct {
 	}
 {{ end }}
 {{- if .QueryParams }}	queryValues := url.Values{}
-{{ range .QueryParams }}	addQueryParam(queryValues, "{{ .OrigName }}", "{{ .Style }}", {{ .Explode }}, params.{{ .FieldName }})
+{{ range .QueryParams }}{{ if serializedParam . }}	addContentQueryParam(queryValues, "{{ .OrigName }}", params.{{ .FieldName }})
+{{ else }}	addQueryParam(queryValues, "{{ .OrigName }}", "{{ .Style }}", {{ .Explode }}, params.{{ .FieldName }})
+{{ end }}
 {{ end }}	if len(queryValues) > 0 {
 		path += "?" + encodeQuery(queryValues)
 	}
 {{ end }}
 {{- if $needHeaders }}	headers := make(http.Header)
-{{ range .HeaderParams }}	setHeader(headers, "{{ .OrigName }}", {{ .Explode }}, params.{{ .FieldName }})
-{{ end }}{{ range .CookieParams }}	addCookieHeader(headers, "{{ .OrigName }}", params.{{ .FieldName }})
+{{ range .HeaderParams }}{{ if serializedParam . }}	setContentHeader(headers, "{{ .OrigName }}", params.{{ .FieldName }})
+{{ else }}	setHeader(headers, "{{ .OrigName }}", {{ .Explode }}, params.{{ .FieldName }})
+{{ end }}{{ end }}{{ range .CookieParams }}{{ if serializedParam . }}	addContentCookieHeader(headers, "{{ .OrigName }}", params.{{ .FieldName }})
+{{ else }}	addCookieHeader(headers, "{{ .OrigName }}", params.{{ .FieldName }})
+{{ end }}
 {{ end }}{{ end }}
 {{- $errType := errorType . -}}
 {{ if successType . }}	var result {{ successType . }}


### PR DESCRIPTION
Closes #77.

```yaml
parameters:
  - name: filter
    in: query
    content:
      application/json:
        schema: { $ref: "#/components/schemas/Filter" }
```

`convertParam` read only `param.Schema` and never looked at `param.Content`, so the parameter lost its type and was encoded with the `form` style:

```go
type ListItemsParams struct {
	Filter *any `json:"filter,omitempty"`   // before
}

addQueryParam(queryValues, "filter", "form", true, params.Filter)
```

Not merely awkward: a struct handed to the style encoder does not come out as the JSON document the server is parsing, so the request was wrong on the wire.

## Now

```go
type ListItemsParams struct {
	Filter *Filter `json:"filter,omitempty"`
}

addContentQueryParam(queryValues, "filter", params.Filter)
```

The value is serialized as the media type it declares, then percent-encoded into the query. Header and cookie parameters get the same treatment through `setContentHeader` and `addContentCookieHeader`.

With #80 merged, the schema behind a content parameter is typed even when written inline, so `content: {application/json: {schema: {type: object, ...}}}` yields a real struct rather than `any`. There is a test for that composition.

## Decisions

- **Only media types the generator can write are serialized.** An `application/xml` content parameter keeps today's style encoding and warns, rather than sending JSON where the server expects something else:

  ```
  warning: parameter "legacy": application/xml is not a media type this generator serializes, so the value is sent style-encoded
  ```

  The warning rides the `pkg.Warnings` channel from #64, now also fed from an analyzer-level buffer.

- **No name hint on the schema branch.** Passing one there types inline unions and objects in style-encoded parameters, which sounds like an improvement and is not: the query encoder writes a synthesized union out as its Go shape (`value=...`) rather than as the value the server parses. `TestNullableUnion_QueryParamsResolveToTheVariantType` caught it. Typed union parameters need the encoder to understand them first, which is separate work.

## Tests

- `internal/analyzer/operations_test.go`: the media type and its schema reach the IR, a style parameter carries no content type, and an unserializable media type produces exactly one warning naming the parameter.
- `internal/generator/e2e_content_param_test.go`: compiles and runs against `httptest`, decoding the query parameter and the header back into the declared type, checking an inline schema is typed and serialized, that a style parameter beside it still goes out unquoted, and that an omitted optional parameter sends nothing rather than `null`.

`gofmt`, `go vet ./...`, and `go test ./...` pass.