### PR TITLE
feat(analyzer): patternProperties types its map, and what stays unsupported says so

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Given any OpenAPI 3.1 (or 3.0) spec, it outputs a complete, idiomatic Go client 
 - **Pagination** — auto-detected cursor/offset pagination with generic `PageIterator[T]`
 - **Retries** — configurable exponential backoff with jitter and `Retry-After` header support
 - **Middleware** — composable request/response middleware chain
-- **OpenAPI 3.1** — full support for JSON Schema 2020-12, nullable type arrays, `$ref` resolution
+- **OpenAPI 3.1**: JSON Schema 2020-12, nullable type arrays, `$ref` resolution ([what is not generated](#not-supported))
 
 ## Installation
 
@@ -271,6 +271,20 @@ A payload that carries no discriminator property at all is still an error — th
 is nothing to identify it by — as is a union *without* a discriminator when no
 variant matches. When the schema declares a `discriminator` but no `mapping`, the
 variant's schema name is used as the discriminator value, per the OpenAPI spec.
+
+## Not supported
+
+Constructs the generator reads and does not act on. Each one warns at generation
+time rather than passing silently:
+
+| Construct | Behavior |
+|---|---|
+| `prefixItems` | The array stays a slice of one element type. A tuple has no Go shape a slice can hold. |
+| `dependentSchemas` | Not enforced. A property whose shape depends on another is a validation rule, not a type. |
+| `patternProperties` with several patterns | The map takes an `any` value type, since the patterns disagree about what a key holds. One pattern types the map. |
+| `links` | Read and not used. Following a link is a decision for the caller, not a generated method. |
+| `webhooks`, `callbacks` | Not generated. |
+| `mutualTLS` security scheme | No auth provider. The certificate is configured on the `http.Client`. |
 
 ## License
 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -30,6 +30,10 @@ type Analyzer struct {
 	// multiContentResponses counts responses offering more than one media type,
 	// of which the generated method decodes one.
 	multiContentResponses int
+	// Keywords read and not expressible in a Go type, reported once per spec.
+	prefixItemsSeen           bool
+	dependentSchemasSeen      bool
+	manyPatternPropertiesSeen bool
 }
 
 // New creates an Analyzer for the given high-level OpenAPI model.
@@ -90,6 +94,19 @@ func (a *Analyzer) Analyze(packageName string) (*ir.Package, error) {
 			noun = "response offers"
 		}
 		pkg.Warnings = append(pkg.Warnings, fmt.Sprintf("%d %s more than one media type; each generated method requests and decodes one, preferring JSON", a.multiContentResponses, noun))
+	}
+
+	for _, note := range []struct {
+		seen bool
+		text string
+	}{
+		{a.prefixItemsSeen, "prefixItems describes a tuple, which has no Go shape a struct can hold, so those arrays stay slices of one element type"},
+		{a.dependentSchemasSeen, "dependentSchemas makes a property's shape conditional, which a Go struct cannot express, so it is not enforced"},
+		{a.manyPatternPropertiesSeen, "patternProperties with more than one pattern disagrees about what a key holds, so those maps take an any value type"},
+	} {
+		if note.seen {
+			pkg.Warnings = append(pkg.Warnings, note.text)
+		}
 	}
 
 	// Append union types synthesized for inline oneOf/anyOf schemas.

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -389,6 +389,8 @@ func (a *Analyzer) convertUnion(goName string, schema *highbase.Schema, variants
 
 // convertObject creates a struct TypeDef from an object schema.
 func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullable, multipartBody bool) (*ir.TypeDef, error) {
+	a.noteUnsupportedKeywords(schema)
+
 	// If no defined properties and additionalProperties is set, generate a map alias.
 	hasProperties := schema.Properties != nil && schema.Properties.Len() > 0
 	if !hasProperties && allowsAdditionalProperties(schema) {
@@ -436,9 +438,28 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 func allowsAdditionalProperties(schema *highbase.Schema) bool {
 	ap := schema.AdditionalProperties
 	if ap == nil {
-		return false
+		// patternProperties admits keys the same way, so a schema with one is
+		// still an object with undeclared members.
+		return schema.PatternProperties != nil && schema.PatternProperties.Len() > 0
 	}
 	return !ap.IsB() || ap.B
+}
+
+// patternPropertiesType returns the value type a schema's patternProperties
+// implies. One pattern types every key it admits; several disagree about what a
+// key holds, and a map has one value type, so those fall back to any.
+func (a *Analyzer) patternPropertiesType(schema *highbase.Schema, nameHint string) string {
+	if schema.PatternProperties == nil || schema.PatternProperties.Len() != 1 {
+		return "any"
+	}
+	for _, proxy := range schema.PatternProperties.FromOldest() {
+		patternSchema, err := proxy.BuildSchema()
+		if err != nil || patternSchema == nil {
+			return "any"
+		}
+		return a.resolveGoType(patternSchema, suffixHint(nameHint, "Value"))
+	}
+	return "any"
 }
 
 // catchAllFieldName picks a Go name for the synthetic additionalProperties field
@@ -494,11 +515,11 @@ func (a *Analyzer) convertAdditionalPropertiesMap(goName string, schema *highbas
 func (a *Analyzer) resolveAdditionalPropertiesType(schema *highbase.Schema, nameHint string) string {
 	ap := schema.AdditionalProperties
 	if ap == nil {
-		return "any"
+		return a.patternPropertiesType(schema, nameHint)
 	}
 	// Bool true means any value type.
 	if ap.IsB() {
-		return "any"
+		return a.patternPropertiesType(schema, nameHint)
 	}
 	// Schema-typed additionalProperties.
 	if ap.IsA() && ap.A != nil {
@@ -549,7 +570,24 @@ func (a *Analyzer) convertPrimitive(goName, primaryType string, schema *highbase
 // to known types, arrays, primitives, and inline unions. nameHint carries the
 // naming context (parent type + field) used when a type must be synthesized;
 // pass "" when no context is available.
+// noteUnsupportedKeywords records the JSON Schema keywords the generator reads
+// and cannot express in a Go type, so the spec's author hears about it once
+// rather than discovering it in the output.
+func (a *Analyzer) noteUnsupportedKeywords(schema *highbase.Schema) {
+	if len(schema.PrefixItems) > 0 {
+		a.prefixItemsSeen = true
+	}
+	if schema.DependentSchemas != nil && schema.DependentSchemas.Len() > 0 {
+		a.dependentSchemasSeen = true
+	}
+	if schema.PatternProperties != nil && schema.PatternProperties.Len() > 1 {
+		a.manyPatternPropertiesSeen = true
+	}
+}
+
 func (a *Analyzer) resolveGoType(schema *highbase.Schema, nameHint string) string {
+	a.noteUnsupportedKeywords(schema)
+
 	// Check if this schema is a $ref pointing to a known component schema.
 	if goType := a.refGoType(schema); goType != "" {
 		return goType

--- a/internal/analyzer/schemas_jsonschema_test.go
+++ b/internal/analyzer/schemas_jsonschema_test.go
@@ -1,0 +1,87 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+)
+
+const jsonSchemaKeywordSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Bags:
+      type: object
+      properties:
+        extensions:
+          type: object
+          patternProperties:
+            "^x-": { type: string }
+        records:
+          type: object
+          patternProperties:
+            "^rec-": { $ref: "#/components/schemas/Record" }
+        mixed:
+          type: object
+          patternProperties:
+            "^s-": { type: string }
+            "^n-": { type: integer }
+        explicit:
+          type: object
+          patternProperties:
+            "^x-": { type: string }
+          additionalProperties: { type: integer }
+        pair:
+          type: array
+          prefixItems: [{ type: string }, { type: integer }]
+    Record:
+      type: object
+      properties:
+        id: { type: string }
+`
+
+// One pattern types every key it admits, which is the common shape: a bag of
+// extension keys that all hold the same thing.
+func TestPatternProperties_OnePatternTypesTheMap(t *testing.T) {
+	_, typeMap := analyzeSpec(t, jsonSchemaKeywordSpec)
+
+	fields := map[string]string{}
+	for _, f := range typeMap["Bags"].Fields {
+		fields[f.JSONName] = f.Type
+	}
+
+	if got := fields["extensions"]; got != "map[string]string" {
+		t.Errorf("extensions = %q, want map[string]string", got)
+	}
+	if got := fields["records"]; got != "map[string]Record" {
+		t.Errorf("records = %q, want map[string]Record", got)
+	}
+	// Several patterns disagree about what a key holds, and a map has one value
+	// type.
+	if got := fields["mixed"]; got != "map[string]any" {
+		t.Errorf("mixed = %q, want map[string]any", got)
+	}
+	// An explicit additionalProperties still wins: it is the stated answer for
+	// keys no pattern claims.
+	if got := fields["explicit"]; got != "map[string]int64" {
+		t.Errorf("explicit = %q, want map[string]int64", got)
+	}
+}
+
+// A keyword the generator reads and cannot express should say so rather than
+// leaving the author to find it in the output.
+func TestUnsupportedKeywords_WarnOncePerSpec(t *testing.T) {
+	pkg, _ := analyzeSpec(t, jsonSchemaKeywordSpec)
+
+	for _, want := range []string{"prefixItems", "patternProperties with more than one pattern"} {
+		var count int
+		for _, w := range pkg.Warnings {
+			if strings.Contains(w, want) {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("warnings mentioning %q = %d, want 1: %v", want, count, pkg.Warnings)
+		}
+	}
+}

--- a/internal/generator/e2e_pattern_properties_test.go
+++ b/internal/generator/e2e_pattern_properties_test.go
@@ -1,0 +1,70 @@
+package generator
+
+import "testing"
+
+const patternPropertiesAPISpec = `openapi: 3.1.0
+info: { title: bags, version: "1" }
+paths:
+  /bags:
+    get:
+      operationId: getBag
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Bag" }
+components:
+  schemas:
+    Bag:
+      type: object
+      properties:
+        name: { type: string }
+        extensions:
+          type: object
+          patternProperties:
+            "^x-": { type: string }
+`
+
+// TestE2E_PatternPropertiesTypesTheMap covers a bag of keys a single pattern
+// admits, which resolved to map[string]any and made every read a type assertion.
+func TestE2E_PatternPropertiesTypesTheMap(t *testing.T) {
+	files, _ := generateFromSpec(t, patternPropertiesAPISpec, "bagsapi")
+
+	runGeneratedWireTest(t, files, "patternprops", `package bagsapi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtensionsDecodeAsStrings(t *testing.T) {
+	var bag Bag
+	payload := `+"`"+`{"name":"b","extensions":{"x-owner":"ada","x-team":"core"}}`+"`"+`
+	if err := json.Unmarshal([]byte(payload), &bag); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// The value type is string, so this is a plain read rather than an assertion.
+	if bag.Extensions["x-owner"] != "ada" {
+		t.Errorf("x-owner = %q, want ada", bag.Extensions["x-owner"])
+	}
+	if len(bag.Extensions) != 2 {
+		t.Errorf("extensions = %v, want both keys", bag.Extensions)
+	}
+
+	bag.Extensions["x-added"] = "later"
+	out, err := json.Marshal(bag)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back Bag
+	if err := json.Unmarshal(out, &back); err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	if back.Extensions["x-added"] != "later" {
+		t.Errorf("round trip lost the added key: %v", back.Extensions)
+	}
+}
+`)
+}


### PR DESCRIPTION
Closes #78.

The README claimed "full support for JSON Schema 2020-12" while three keywords were read by nothing.

## patternProperties types the map

```yaml
extensions:
  type: object
  patternProperties:
    "^x-": { type: string }
```

```go
Extensions map[string]any     // before
Extensions map[string]string  // now
```

Every read stops being a type assertion. A `$ref` pattern works the same way, giving `map[string]Record`.

Rules:

- **One pattern types the map.** That is the common shape: a bag of keys that all hold the same thing.
- **Several patterns keep `any`,** since they disagree about what a key holds and a Go map has one value type.
- **An explicit `additionalProperties` still wins.** It is the stated answer for keys no pattern claims.
- A schema carrying only `patternProperties` now counts as admitting undeclared members, which it did not before, so it maps rather than producing an empty struct.

## The rest say so instead of vanishing

`prefixItems` describes a tuple, which no Go slice holds, and `dependentSchemas` makes a property's shape conditional, which no struct expresses. Neither is generated, and both now warn once per spec:

```
warning: prefixItems describes a tuple, which has no Go shape a struct can hold, so those arrays stay slices of one element type
warning: dependentSchemas makes a property's shape conditional, which a Go struct cannot express, so it is not enforced
```

The README's "full support" claim is replaced by a link to a new "Not supported" table listing these, plus `links`, `webhooks` and `callbacks`, and `mutualTLS`. Claiming less and listing it is worth more than the claim.

## Tests

- `internal/analyzer/schemas_jsonschema_test.go`: one pattern types the map for both a primitive and a `$ref`, several patterns fall back to `any`, an explicit `additionalProperties` wins, and each unsupported keyword warns exactly once.
- `internal/generator/e2e_pattern_properties_test.go`: compiles and runs a client that reads a typed extensions map without an assertion, adds a key, and round-trips it through JSON.

`gofmt`, `go vet ./...`, and `go test ./...` pass.