### PR TITLE
fix(generator): a binary or text response body was run through json.Unmarshal

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -27,6 +27,9 @@ type Analyzer struct {
 	// before any conversion so a reference to a schema that has not been converted
 	// yet still resolves to the name it will end up with.
 	goNameBySchema map[string]string
+	// multiContentResponses counts responses offering more than one media type,
+	// of which the generated method decodes one.
+	multiContentResponses int
 }
 
 // New creates an Analyzer for the given high-level OpenAPI model.
@@ -79,6 +82,14 @@ func (a *Analyzer) Analyze(packageName string) (*ir.Package, error) {
 	// Analyze security schemes.
 	if err := a.analyzeSecuritySchemes(pkg); err != nil {
 		return nil, err
+	}
+
+	if a.multiContentResponses > 0 {
+		noun := "responses offer"
+		if a.multiContentResponses == 1 {
+			noun = "response offers"
+		}
+		pkg.Warnings = append(pkg.Warnings, fmt.Sprintf("%d %s more than one media type; each generated method requests and decodes one, preferring JSON", a.multiContentResponses, noun))
 	}
 
 	// Append union types synthesized for inline oneOf/anyOf schemas.

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -520,6 +520,10 @@ func (a *Analyzer) convertSingleResponse(code string, resp *v3high.Response, nam
 
 	rd.Headers = convertResponseHeaders(resp)
 
+	if resp.Content != nil && resp.Content.Len() > 1 {
+		a.multiContentResponses++
+	}
+
 	if resp.Content != nil {
 		for contentType, mediaType := range resp.Content.FromOldest() {
 			if strings.Contains(contentType, "json") {

--- a/internal/analyzer/operations_test.go
+++ b/internal/analyzer/operations_test.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
@@ -484,5 +485,52 @@ func TestResponseHeaders_TypedOnlyWhereTextParses(t *testing.T) {
 	}
 	if byName["X-Request-Id"].GoName != "XRequestID" {
 		t.Errorf("X-Request-Id GoName = %q, want XRequestID", byName["X-Request-Id"].GoName)
+	}
+}
+
+const multiMediaResponseSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /docs:
+    get:
+      operationId: getDoc
+      responses:
+        "200":
+          description: ok
+          content:
+            application/xml: { schema: { type: string } }
+            application/json: { schema: { type: string } }
+  /one:
+    get:
+      operationId: getOne
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { type: string } }
+`
+
+// A response offering several media types still decodes one, and the author
+// hears which rather than discovering it from the Accept header.
+func TestMultiMediaResponse_PrefersJSONAndSaysSo(t *testing.T) {
+	pkg, _ := analyzeSpec(t, multiMediaResponseSpec)
+
+	for _, op := range pkg.Operations {
+		if op.Name == "GetDoc" && op.SuccessResponse.ContentType != "application/json" {
+			t.Errorf("GetDoc content type = %q, want application/json even though XML comes first", op.SuccessResponse.ContentType)
+		}
+	}
+
+	var found int
+	for _, w := range pkg.Warnings {
+		if strings.Contains(w, "more than one media type") {
+			found++
+			if !strings.Contains(w, "1 response offers") {
+				t.Errorf("warning = %q, want it to count the one response that offers several", w)
+			}
+		}
+	}
+	if found != 1 {
+		t.Errorf("media type warnings = %d, want 1: %v", found, pkg.Warnings)
 	}
 }

--- a/internal/generator/e2e_response_media_test.go
+++ b/internal/generator/e2e_response_media_test.go
@@ -1,0 +1,113 @@
+package generator
+
+import "testing"
+
+const responseMediaSpec = `openapi: 3.1.0
+info: { title: files, version: "1" }
+paths:
+  /file:
+    get:
+      operationId: downloadFile
+      responses:
+        "200":
+          description: ok
+          content:
+            application/octet-stream:
+              schema: { type: string, format: binary }
+  /notes:
+    get:
+      operationId: getNote
+      responses:
+        "200":
+          description: ok
+          content:
+            text/plain:
+              schema: { type: string }
+  /docs:
+    get:
+      operationId: getDoc
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Doc" }
+components:
+  schemas:
+    Doc:
+      type: object
+      properties:
+        id: { type: string }
+`
+
+// TestE2E_ResponseBodyByMediaType covers bodies that are the value rather than a
+// document to parse. A binary download was run through json.Unmarshal, so it
+// failed on the first byte and no file could be fetched at all.
+func TestE2E_ResponseBodyByMediaType(t *testing.T) {
+	files, _ := generateFromSpec(t, responseMediaSpec, "filesapi")
+
+	runGeneratedWireTest(t, files, "responsemedia", `package filesapi
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func serve(t *testing.T, contentType string, body []byte) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL)
+}
+
+func TestBinaryBodyArrivesVerbatim(t *testing.T) {
+	payload := []byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0xff}
+	got, err := serve(t, "application/octet-stream", payload).DownloadFile(t.Context())
+	if err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	if got == nil || !bytes.Equal(*got, payload) {
+		t.Errorf("body = %v, want the bytes the server sent", got)
+	}
+}
+
+func TestTextBodyArrivesVerbatim(t *testing.T) {
+	got, err := serve(t, "text/plain", []byte("not json {")).GetNote(t.Context())
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	if got == nil || *got != "not json {" {
+		t.Errorf("body = %v, want the text the server sent", got)
+	}
+}
+
+// A server that labels JSON as something else is common enough to try anyway.
+func TestMislabeledJSONStillDecodes(t *testing.T) {
+	doc, err := serve(t, "text/html", []byte(`+"`"+`{"id":"d-1"}`+"`"+`)).GetDoc(t.Context())
+	if err != nil {
+		t.Fatalf("GetDoc: %v", err)
+	}
+	if doc == nil || doc.ID == nil || *doc.ID != "d-1" {
+		t.Errorf("doc = %+v, want the decoded body", doc)
+	}
+}
+
+// When it is not JSON either, the error names both media types instead of
+// reporting a parse failure with no context.
+func TestMediaTypeMismatchNamesBoth(t *testing.T) {
+	_, err := serve(t, "application/xml", []byte("<doc><id>d-1</id></doc>")).GetDoc(t.Context())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "application/json") || !strings.Contains(err.Error(), "application/xml") {
+		t.Errorf("error = %q, want it to name what was asked for and what arrived", err)
+	}
+}
+`)
+}

--- a/internal/generator/e2e_test.go
+++ b/internal/generator/e2e_test.go
@@ -252,8 +252,10 @@ func TestE2E_TextPlainGeneration(t *testing.T) {
 	if !strings.Contains(clientContent, `resp.Header.Get("Content-Type")`) {
 		t.Error("client.go should check response Content-Type header")
 	}
-	if !strings.Contains(clientContent, `result.(*string)`) {
-		t.Error("client.go should have *string type assertion for text responses")
+	// A body typed as text or bytes is taken verbatim rather than parsed;
+	// e2e_response_media_test.go exercises what that does at runtime.
+	if !strings.Contains(clientContent, "isRawResult(result") {
+		t.Error("client.go should take a text or binary body verbatim")
 	}
 
 	t.Log("text/plain generated code compiles successfully")

--- a/internal/templates/client.go.tmpl
+++ b/internal/templates/client.go.tmpl
@@ -183,15 +183,19 @@ func (c *Client) do(ctx context.Context, method string, path string, body any, c
 
 		if result != nil && len(respBody) > 0 {
 			ct := resp.Header.Get("Content-Type")
-			if strings.Contains(ct, "json") || ct == "" {
+			switch {
+			case strings.Contains(ct, "json") || ct == "":
 				if err := json.Unmarshal(respBody, result); err != nil {
 					return fmt.Errorf("decoding response body: %w", err)
 				}
-			} else if s, ok := result.(*string); ok {
-				*s = string(respBody)
-			} else {
+			case isRawResult(result, respBody):
+				// A body the operation types as bytes or text is itself the value,
+				// so it is taken verbatim rather than parsed.
+			default:
+				// A server that labels JSON as something else is common enough to
+				// try anyway, and the media types name each other when it fails.
 				if err := json.Unmarshal(respBody, result); err != nil {
-					return fmt.Errorf("decoding response body: %w", err)
+					return fmt.Errorf("decoding response body: asked for %s and the server sent %s: %w", accept, ct, err)
 				}
 			}
 		}

--- a/internal/templates/helpers.go.tmpl
+++ b/internal/templates/helpers.go.tmpl
@@ -364,6 +364,21 @@ func pathSep(explode bool, exploded string) string {
 	return ","
 }
 
+// isRawResult fills a result the operation types as bytes or text with the body
+// as it arrived, reporting whether it did. Such a body is the value itself, not
+// a document to parse.
+func isRawResult(result any, body []byte) bool {
+	switch v := result.(type) {
+	case *[]byte:
+		*v = body
+		return true
+	case *string:
+		*v = string(body)
+		return true
+	}
+	return false
+}
+
 // setHeader sets a header parameter (simple style), skipping a nil optional
 // pointer.
 func setHeader(headers http.Header, name string, explode bool, value any) {


### PR DESCRIPTION
Closes #76, and fixes something worse that turned up while reading that path.

## Binary responses could not be fetched at all

```yaml
/file:
  get:
    operationId: downloadFile
    responses:
      "200":
        content:
          application/octet-stream:
            schema: { type: string, format: binary }
```

The generated method types the result `[]byte` and hands it to `do`, which ran it through `json.Unmarshal`:

```
DownloadFile: decoding response body: invalid character '\u0089' looking for beginning of value
```

Every binary download failed on the first byte. A text body only worked because a `*string` assertion happened to sit beside the JSON path.

A body the operation types as bytes or text is now taken verbatim, since such a body is the value rather than a document to parse.

## The mismatch error says what happened

My description in #76 was wrong on one point: a non-JSON body was not silently skipped, it was run through `json.Unmarshal` and failed with a parse error carrying no context. Both halves are addressed:

- A body labeled something other than JSON is still tried as JSON, because servers mislabel constantly and a working decode is better than a principled failure.
- When that fails, the error names both media types: `asked for application/json and the server sent application/xml: ...`

## Several media types still decode one

Choosing another representation needs a decision about generated API shape that this PR does not make, so the behavior is unchanged and now says so:

```
warning: 1 response offers more than one media type; each generated method requests and decodes one, preferring JSON
```

Counted once per spec rather than per response, since a spec that offers JSON and XML tends to do it everywhere.

## One existing assertion changed

`TestE2E_TextPlainGeneration` asserted the generated `client.go` contains `result.(*string)`. That assertion moved with the code into `isRawResult`, so it now checks the call site, and the runtime behavior it stood in for is covered directly in the new e2e.

## Tests

`internal/generator/e2e_response_media_test.go` compiles and runs against `httptest`: a binary body arrives byte for byte, a text body arrives verbatim including invalid JSON, JSON mislabeled `text/html` still decodes, and a genuine XML mismatch produces an error naming both media types.

`internal/analyzer/operations_test.go`: JSON is preferred even when XML is declared first, and the multi-media warning counts responses rather than firing per operation.

`gofmt`, `go vet ./...`, and `go test ./...` pass.
