### PR TITLE
feat(analyzer): a union parameter names a type instead of resting at any

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,33 @@ included, stays the raw string. Error responses are captured too, which is where
 a rate limit usually arrives. Calls made with the returned context each overwrite
 the meta, so give one capture to one call.
 
+### Union and object parameters
+
+A parameter whose schema is a union with a genuine choice names a type, so the
+values it accepts are visible in Go rather than hidden behind `any`:
+
+```yaml
+- name: either
+  in: query
+  schema:
+    anyOf: [{ type: string }, { type: integer }]
+```
+
+```go
+either := petstore.ListItemsEither{Value: 42}
+client.ListItems(ctx, petstore.ListItemsParams{Either: &either})
+// ?either=42
+```
+
+The value the union carries is what goes on the wire, under the parameter's own
+style, so a list variant still explodes and a scalar still goes out as itself. A
+union carrying nothing sends no parameter at all. One shape is one type, so two
+parameters declaring the same union share it.
+
+`anyOf: [string, null]` is not a choice of that kind and still collapses to
+`*string`, as do variants that refine a single Go type. Objects written inline in
+a parameter are named the same way, and keep encoding under their style.
+
 ### Error messages
 
 `Error()` on a typed error wrapper prints the raw response body, which is the

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -384,10 +384,7 @@ func (a *Analyzer) convertParam(param *v3high.Parameter, opName string) (*ir.Par
 			return nil, fmt.Errorf("building param schema: %w", err)
 		}
 		if schema != nil {
-			// No name hint: a style-encoded parameter is written into the URL by
-			// the query encoder, and a synthesized union or struct would go out
-			// as its Go shape rather than as the value the server parses.
-			goType = a.resolveGoType(schema, "")
+			goType = a.resolveGoType(schema, opName+naming.Exported(param.Name))
 		}
 	case param.Content != nil:
 		// A parameter with content carries a document, and the media type says how

--- a/internal/analyzer/operations_test.go
+++ b/internal/analyzer/operations_test.go
@@ -653,3 +653,66 @@ func TestLinks_WarnOncePerSpec(t *testing.T) {
 		t.Errorf("link warnings = %d, want 1: %v", linkWarnings, pkg.Warnings)
 	}
 }
+
+const unionParamAnalyzerSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: either
+          in: query
+          schema:
+            anyOf: [{ type: string }, { type: integer }]
+        - name: same
+          in: query
+          schema:
+            anyOf: [{ type: string }, { type: integer }]
+        - name: maybe
+          in: query
+          schema:
+            anyOf: [{ type: string }, { type: "null" }]
+        - name: shaped
+          in: query
+          schema:
+            type: object
+            properties:
+              lat: { type: number }
+              lon: { type: number }
+      responses:
+        "204": { description: ok }
+`
+
+// A parameter with a genuine choice of types names one, which is what makes it
+// constructible. A nullable union still collapses to its one variant.
+func TestUnionParam_NamesItsType(t *testing.T) {
+	pkg, typeMap := analyzeSpec(t, unionParamAnalyzerSpec)
+
+	params := make(map[string]*ir.ParamDef)
+	for _, op := range pkg.Operations {
+		for _, p := range op.QueryParams {
+			params[p.OrigName] = p
+		}
+	}
+
+	either := params["either"]
+	if either == nil || either.Type != "ListItemsEither" {
+		t.Fatalf("either type = %+v, want a named union", either)
+	}
+	if td := typeMap[either.Type]; td == nil || td.Kind != ir.TypeKindUnion {
+		t.Errorf("%s = %+v, want a generated union", either.Type, td)
+	}
+	// One shape is one type, so a second parameter of the same shape shares it.
+	if same := params["same"]; same == nil || same.Type != either.Type {
+		t.Errorf("same type = %+v, want %q", same, either.Type)
+	}
+	// Nullability is carried by the pointer, not by a union.
+	if maybe := params["maybe"]; maybe == nil || maybe.Type != "string" {
+		t.Errorf("maybe type = %+v, want string", maybe)
+	}
+	// An object written inline in a parameter is named for the same reason.
+	if shaped := params["shaped"]; shaped == nil || shaped.Type != "ListItemsShaped" {
+		t.Errorf("shaped type = %+v, want ListItemsShaped", shaped)
+	}
+}

--- a/internal/analyzer/schemas_nullable_union_test.go
+++ b/internal/analyzer/schemas_nullable_union_test.go
@@ -189,8 +189,9 @@ func TestNullableUnion_QueryParamsResolveToTheVariantType(t *testing.T) {
 		// Variants that are refinements of one Go type collapse to that type.
 		{"cookbook", "string"},
 		{"categories", "[]string"},
-		// A union with a real choice keeps its union handling.
-		{"either", "any"},
+		// A union with a real choice names a type, which is what makes the
+		// parameter constructible.
+		{"either", "ListRecipesEither"},
 	}
 	for _, tt := range tests {
 		p := params[tt.param]

--- a/internal/generator/e2e_union_param_test.go
+++ b/internal/generator/e2e_union_param_test.go
@@ -1,0 +1,179 @@
+package generator
+
+import "testing"
+
+const unionParamSpec = `openapi: 3.1.0
+info: { title: search, version: "1" }
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: either
+          in: query
+          schema:
+            anyOf: [{ type: string }, { type: integer }]
+        - name: ids
+          in: query
+          schema:
+            anyOf:
+              - { type: array, items: { type: string } }
+              - { type: string }
+        - name: X-Either
+          in: header
+          schema:
+            anyOf: [{ type: string }, { type: integer }]
+        - name: plain
+          in: query
+          schema: { type: string }
+        - name: at
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            properties:
+              lat: { type: number }
+              lon: { type: number }
+            required: [lat, lon]
+      responses:
+        "204": { description: ok }
+  /items/{id}:
+    get:
+      operationId: getItem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            anyOf: [{ type: string }, { type: integer }]
+      responses:
+        "204": { description: ok }
+`
+
+// TestE2E_UnionParamsSendTheValue covers a parameter whose schema is a union with
+// a real choice. Typing it is only safe if the encoders write the value the union
+// carries rather than the wrapper carrying it.
+func TestE2E_UnionParamsSendTheValue(t *testing.T) {
+	files, _ := generateFromSpec(t, unionParamSpec, "searchapi")
+
+	runGeneratedWireTest(t, files, "unionparam", `package searchapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func capture(t *testing.T) (*Client, *http.Request) {
+	t.Helper()
+	var got http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = *r
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL), &got
+}
+
+func TestScalarVariantGoesOutAsItself(t *testing.T) {
+	client, got := capture(t)
+
+	either := ListItemsEither{Value: 42}
+	if err := client.ListItems(t.Context(), ListItemsParams{Either: &either}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if q := got.URL.Query().Get("either"); q != "42" {
+		t.Errorf("either = %q, want 42 rather than the wrapper's shape", q)
+	}
+}
+
+func TestStringVariantGoesOutAsItself(t *testing.T) {
+	client, got := capture(t)
+
+	either := ListItemsEither{Value: "abc"}
+	if err := client.ListItems(t.Context(), ListItemsParams{Either: &either}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if q := got.URL.Query().Get("either"); q != "abc" {
+		t.Errorf("either = %q, want abc", q)
+	}
+}
+
+// A list variant still explodes the way the style says, since unwrapping happens
+// before the style is applied rather than instead of it.
+func TestListVariantKeepsItsStyle(t *testing.T) {
+	client, got := capture(t)
+
+	ids := ListItemsIds{Value: []string{"a", "b"}}
+	if err := client.ListItems(t.Context(), ListItemsParams{Ids: &ids}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if values := got.URL.Query()["ids"]; len(values) != 2 || values[0] != "a" || values[1] != "b" {
+		t.Errorf("ids = %v, want the exploded list", values)
+	}
+}
+
+func TestHeaderAndPathUnwrapToo(t *testing.T) {
+	client, got := capture(t)
+
+	// One shape is one type, so the header parameter shares the union the query
+	// parameter named rather than declaring a second identical wrapper.
+	either := ListItemsEither{Value: 7}
+	if err := client.ListItems(t.Context(), ListItemsParams{XEither: &either}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if h := got.Header.Get("X-Either"); h != "7" {
+		t.Errorf("X-Either = %q, want 7", h)
+	}
+
+	client, got = capture(t)
+	if err := client.GetItem(t.Context(), ListItemsEither{Value: "abc"}); err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if got.URL.Path != "/items/abc" {
+		t.Errorf("path = %q, want the value in place of the wrapper", got.URL.Path)
+	}
+}
+
+// An empty union sends nothing rather than a zero of some variant's type.
+func TestEmptyUnionIsOmitted(t *testing.T) {
+	client, got := capture(t)
+
+	var either ListItemsEither
+	if err := client.ListItems(t.Context(), ListItemsParams{Either: &either}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if _, ok := got.URL.Query()["either"]; ok {
+		t.Errorf("query = %q, want no parameter for a union carrying nothing", got.URL.RawQuery)
+	}
+}
+
+// An object written inline in a parameter is hintless for the same reason a
+// union is, so it is typed by the same change and still encodes under its style.
+func TestInlineObjectParamIsTypedAndStyled(t *testing.T) {
+	client, got := capture(t)
+
+	at := ListItemsAt{Lat: 51.5, Lon: -0.12}
+	if err := client.ListItems(t.Context(), ListItemsParams{At: &at}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	q := got.URL.Query()
+	if q.Get("at[lat]") != "51.5" || q.Get("at[lon]") != "-0.12" {
+		t.Errorf("query = %q, want the object exploded under deepObject", got.URL.RawQuery)
+	}
+}
+
+func TestPlainParamIsUnaffected(t *testing.T) {
+	client, got := capture(t)
+
+	value := "hello"
+	if err := client.ListItems(t.Context(), ListItemsParams{Plain: &value}); err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if q := got.URL.Query().Get("plain"); q != "hello" {
+		t.Errorf("plain = %q", q)
+	}
+}
+`)
+}

--- a/internal/templates/helpers.go.tmpl
+++ b/internal/templates/helpers.go.tmpl
@@ -46,7 +46,17 @@ func derefParam(value any) (reflect.Value, bool) {
 		}
 		rv = rv.Elem()
 	}
+	// A union is a wrapper around the value it decoded, and the server is owed
+	// the value, not the wrapper.
+	if u, ok := rv.Interface().(unionValuer); ok {
+		return derefParam(u.unionValue())
+	}
 	return rv, true
+}
+
+// unionValuer is implemented by every generated union.
+type unionValuer interface {
+	unionValue() any
 }
 
 // isSlice reports whether rv is a multi-value slice; a []byte is a scalar

--- a/internal/templates/types.go.tmpl
+++ b/internal/templates/types.go.tmpl
@@ -312,6 +312,12 @@ func (u {{ .Name }}) Base() *{{ .BaseType }} {
 	return nil
 }
 {{ end }}
+// unionValue hands the decoded variant to the parameter encoders, which write
+// the value a union carries rather than the wrapper carrying it.
+func (u {{ .Name }}) unionValue() any {
+	return u.Value
+}
+
 // MarshalJSON implements json.Marshaler for {{ .Name }}.
 func (u {{ .Name }}) MarshalJSON() ([]byte, error) {
 {{- if .Discriminator }}


### PR DESCRIPTION
Closes #87.

```yaml
- name: either
  in: query
  schema:
    anyOf: [{ type: string }, { type: integer }]
```

```go
type ListItemsParams struct {
	Either *any `json:"either,omitempty"`   // before
}
```

Assignable, since everything satisfies `any`, but nothing in the generated package said what was valid. This is the tail of #16.

## Why it was blocked, and what unblocked it

#82 deliberately withheld the name hint here. Synthesizing the type is easy; the problem is that a union is a struct, and the query encoder writes a struct as an object, so `either=42` would have gone out as the wrapper's shape. Typing the field would have made the wire wrong.

Every generated union now answers an unexported marker:

```go
func (u ListItemsEither) unionValue() any { return u.Value }
```

and `derefParam`, which every parameter encoder already goes through, unwraps it:

```go
if u, ok := rv.Interface().(unionValuer); ok {
	return derefParam(u.unionValue())
}
```

One place, so query, header, path, and cookie parameters all benefit. An unexported method rather than sniffing for a struct with a field named `Value`, which a schema could legitimately declare.

With the wire correct, the analyzer passes the hint:

```go
either := ListItemsEither{Value: 42}
client.ListItems(ctx, ListItemsParams{Either: &either})   // ?either=42
```

## Behavior worth knowing

- **Unwrapping happens before the style is applied,** not instead of it, so a list variant still explodes and a `deepObject` object parameter still explodes.
- **A union carrying nothing sends no parameter,** rather than a zero of some variant's type.
- **One shape is one type.** Two parameters declaring the same union share it, so a header parameter reuses the type a query parameter named. That also means a path parameter's type can be named after the operation that declared the shape first: `GetItem(ctx, id ListItemsEither)`. Existing behavior for inline unions, now visible in a signature.
- **Nullable unions are untouched:** `anyOf: [string, null]` still collapses to `*string`.
- **Inline objects in parameters ride along,** since they were hintless for the same reason, and still encode under their style.

## Tests

- `internal/analyzer/operations_test.go`: a union parameter names a union type, two parameters of one shape share it, a nullable union still collapses to `string`, and an inline object parameter is named.
- `internal/generator/e2e_union_param_test.go`: compiles and runs against `httptest`, checking an integer variant arrives as `42` and a string variant as `abc`, a list variant still explodes, header and path parameters unwrap too, an empty union sends nothing, a `deepObject` inline object explodes into `at[lat]` and `at[lon]`, and a plain parameter is unaffected.

One existing expectation changed: `TestNullableUnion_QueryParamsResolveToTheVariantType` asserted that a real choice stays `any`, which was the behavior this replaces.

`gofmt`, `go vet ./...`, and `go test ./...` pass.