### PR TITLE
feat(generator): an error body names its message, extension or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,11 @@ a parameter are named the same way, and keep encoding under their style.
 
 ### Error messages
 
-`Error()` on a typed error wrapper prints the raw response body, which is the
-only safe default: nothing in a spec says which property of an error schema
-holds the human-readable message.
+`Error()` on a typed error wrapper renders the property that carries the
+human-readable message, falling back to the raw body when it finds none.
 
-A schema can say so with Kiota's `x-ms-primary-error-message` extension. Mark the
-property that carries the message:
+A schema names that property in one of two ways. Marking it is exact, either with
+the vendor-neutral `x-error-message` or with Kiota's `x-ms-primary-error-message`:
 
 ```yaml
 components:
@@ -237,7 +236,7 @@ components:
           type: integer
         message:
           type: string
-          x-ms-primary-error-message: true
+          x-error-message: true
 ```
 
 `Error()` then renders that property instead of the body:
@@ -250,6 +249,13 @@ The marked property has to be a string, and the first one a schema marks is the
 one used. When it is empty, or the body does not parse, the output falls back to
 the raw body, so a message never disappears. `Detail` still holds the whole
 parsed body either way.
+
+A schema that marks nothing is read by the names error bodies conventionally use,
+most specific first: `message`, `detail`, `error_description`, `title`, `error`.
+A body carrying several is tried in that order at runtime, so an RFC 7807
+response renders `detail` when it has one and `title` when it does not. A body
+with no such property, or with one holding something other than text, keeps the
+raw output.
 
 ### Webhooks and callbacks
 

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -282,22 +282,29 @@ func (a *Analyzer) convertProperty(goName, propName string, propSchema *highbase
 	}
 }
 
-// isPrimaryErrorMessage reports whether a property schema carries Kiota's
-// x-ms-primary-error-message extension marking it as the human-readable
-// error message.
+// isPrimaryErrorMessage reports whether a property schema is marked as the
+// human-readable error message, by Kiota's x-ms-primary-error-message or by the
+// vendor-neutral x-error-message.
 func isPrimaryErrorMessage(schema *highbase.Schema) bool {
 	if schema.Extensions == nil {
 		return false
 	}
 	for name, node := range schema.Extensions.FromOldest() {
-		if name != "x-ms-primary-error-message" || node == nil {
+		// x-error-message says the same thing without asking a producer to emit
+		// another toolchain's vocabulary.
+		if name != "x-ms-primary-error-message" && name != "x-error-message" {
+			continue
+		}
+		if node == nil {
 			continue
 		}
 		var enabled bool
 		if err := node.Decode(&enabled); err != nil {
-			return false
+			continue
 		}
-		return enabled
+		if enabled {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/generator/e2e_error_message_names_test.go
+++ b/internal/generator/e2e_error_message_names_test.go
@@ -1,0 +1,143 @@
+package generator
+
+import "testing"
+
+const messageNameSpec = `openapi: 3.1.0
+info: { title: errs, version: "1" }
+paths:
+  /a:
+    get:
+      operationId: getA
+      responses:
+        "200": { description: ok, content: { application/json: { schema: { type: string } } } }
+        default:
+          description: err
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Problem" } }
+  /b:
+    get:
+      operationId: getB
+      responses:
+        "200": { description: ok, content: { application/json: { schema: { type: string } } } }
+        default:
+          description: err
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Oauth" } }
+  /c:
+    get:
+      operationId: getC
+      responses:
+        "200": { description: ok, content: { application/json: { schema: { type: string } } } }
+        default:
+          description: err
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Marked" } }
+  /d:
+    get:
+      operationId: getD
+      responses:
+        "200": { description: ok, content: { application/json: { schema: { type: string } } } }
+        default:
+          description: err
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Typed" } }
+components:
+  schemas:
+    Problem:
+      type: object
+      properties:
+        type: { type: string }
+        title: { type: string }
+        detail: { type: string }
+        status: { type: integer }
+    Oauth:
+      type: object
+      properties:
+        error: { type: string }
+        error_description: { type: string }
+    Marked:
+      type: object
+      properties:
+        message: { type: string }
+        note:
+          type: string
+          x-error-message: true
+    Typed:
+      type: object
+      properties:
+        message: { type: integer }
+        detail: { type: string }
+`
+
+// TestE2E_ErrorMessageNames covers the error bodies that mark nothing, which is
+// most of them: Error() printed the whole JSON body rather than the property
+// that carries the message.
+func TestE2E_ErrorMessageNames(t *testing.T) {
+	files, _ := generateFromSpec(t, messageNameSpec, "errsapi")
+
+	runGeneratedWireTest(t, files, "messagenames", `package errsapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func rendered(t *testing.T, err error) string {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	return err.Error()
+}
+
+// RFC 7807 carries both title and detail, and detail is the specific one.
+func TestProblemPrefersDetail(t *testing.T) {
+	err := parseProblemResponse(&APIError{StatusCode: 400, Status: "400 Bad Request", Body: []byte(`+"`"+`{"title":"Bad Request","detail":"name is required"}`+"`"+`)})
+	if got := rendered(t, err); got != "API error 400 Bad Request: name is required" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+// With only title, that is the message.
+func TestProblemFallsBackToTitle(t *testing.T) {
+	err := parseProblemResponse(&APIError{StatusCode: 400, Status: "400 Bad Request", Body: []byte(`+"`"+`{"title":"Bad Request"}`+"`"+`)})
+	if got := rendered(t, err); got != "API error 400 Bad Request: Bad Request" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+// OAuth error bodies name the human-readable half error_description, with error
+// holding a code.
+func TestOAuthPrefersDescription(t *testing.T) {
+	err := parseOauthResponse(&APIError{StatusCode: 401, Status: "401 Unauthorized", Body: []byte(`+"`"+`{"error":"invalid_grant","error_description":"Token expired"}`+"`"+`)})
+	if got := rendered(t, err); got != "API error 401 Unauthorized: Token expired" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+// A marked property wins over a conventionally named one, whichever vocabulary
+// marked it.
+func TestMarkedPropertyWins(t *testing.T) {
+	err := parseMarkedResponse(&APIError{StatusCode: 500, Status: "500 Internal Server Error", Body: []byte(`+"`"+`{"message":"generic","note":"the real one"}`+"`"+`)})
+	if got := rendered(t, err); got != "API error 500 Internal Server Error: the real one" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+// A conventional name holding something other than text is not the message.
+func TestNonStringNameIsSkipped(t *testing.T) {
+	err := parseTypedResponse(&APIError{StatusCode: 500, Status: "500 Internal Server Error", Body: []byte(`+"`"+`{"message":7,"detail":"the real one"}`+"`"+`)})
+	if got := rendered(t, err); got != "API error 500 Internal Server Error: the real one" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+// An empty message still falls back to the body, so nothing disappears.
+func TestEmptyConventionalMessageFallsBack(t *testing.T) {
+	err := parseProblemResponse(&APIError{StatusCode: 400, Status: "400 Bad Request", Body: []byte(`+"`"+`{"detail":""}`+"`"+`)})
+	if got := rendered(t, err); !strings.Contains(got, `+"`"+`{"detail":""}`+"`"+`) {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+`)
+}

--- a/internal/generator/e2e_error_message_test.go
+++ b/internal/generator/e2e_error_message_test.go
@@ -61,6 +61,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Bare"
+  /doodads:
+    get:
+      operationId: listDoodads
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Widget"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Opaque"
 components:
   schemas:
     Widget:
@@ -89,6 +107,16 @@ components:
       properties:
         message:
           type: string
+    Opaque:
+      type: object
+      properties:
+        code:
+          type: integer
+        trace:
+          type: object
+          properties:
+            span:
+              type: string
 `
 
 // TestE2E_ErrorResponseMessage verifies a parsed error response surfaces the
@@ -119,9 +147,19 @@ func TestAnnotatedPointerFieldRendered(t *testing.T) {
 	}
 }
 
-func TestUnannotatedSchemaKeepsBody(t *testing.T) {
-	err := parseBareResponse(&APIError{StatusCode: 404, Status: "404 Not Found", Body: []byte(` + "`" + `{"message":"not rendered"}` + "`" + `)})
-	if got := err.Error(); !strings.Contains(got, ` + "`" + `{"message":"not rendered"}` + "`" + `) {
+// A schema that marks nothing still names its message the way most APIs do.
+func TestConventionalNameIsRendered(t *testing.T) {
+	err := parseBareResponse(&APIError{StatusCode: 404, Status: "404 Not Found", Body: []byte(` + "`" + `{"message":"Widget not found"}` + "`" + `)})
+	if got := err.Error(); got != "API error 404 Not Found: Widget not found" {
+		t.Fatalf("Error() = %q", got)
+	}
+}
+
+// A body with no property that reads as a message keeps the raw output, which is
+// the only honest thing to print.
+func TestBodyWithoutAMessageKeepsBody(t *testing.T) {
+	err := parseOpaqueResponse(&APIError{StatusCode: 500, Status: "500 Internal Server Error", Body: []byte(` + "`" + `{"code":7}` + "`" + `)})
+	if got := err.Error(); !strings.Contains(got, ` + "`" + `{"code":7}` + "`" + `) {
 		t.Fatalf("Error() = %q", got)
 	}
 }

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -50,7 +50,7 @@ func FuncMap() template.FuncMap {
 		"paginationCursorField":   paginationCursorField,
 		"toGoName":                naming.Exported,
 		"uniqueErrorTypes":        uniqueErrorTypes,
-		"errorMessageField":       errorMessageField,
+		"errorMessageFields":      errorMessageFields,
 		"errorType":               errorType,
 		"successContentType":      successContentType,
 		"requestContentType":      requestContentType,
@@ -784,20 +784,57 @@ type ErrorWrapper struct {
 	Detail string
 }
 
-// errorMessageField returns the error type's string field annotated with
-// x-ms-primary-error-message, or nil when the spec designates none.
-func errorMessageField(pkg *ir.Package, typeName string) *ir.Field {
+// errorMessageFields returns the string properties of an error body that can
+// stand in for it in Error(), most specific first: the one the spec marks, or
+// the ones named the way error bodies conventionally name a message.
+func errorMessageFields(pkg *ir.Package, typeName string) []*ir.Field {
 	for _, t := range pkg.Types {
 		if t.Name != typeName || t.Kind != ir.TypeKindStruct {
 			continue
 		}
 		for _, f := range t.Fields {
-			if f.PrimaryErrorMessage && (f.Type == "string" || f.Type == "*string") {
-				return f
+			// A property the spec marks is the message, and an empty one falls
+			// back to the body rather than to a neighbor.
+			if f.PrimaryErrorMessage && isStringField(f) {
+				return []*ir.Field{f}
+			}
+		}
+		return conventionalMessageFields(t)
+	}
+	return nil
+}
+
+// conventionalErrorMessageNames are the property names an error body carries its
+// human-readable message under, most specific first. RFC 7807 supplies detail
+// and title; the rest are what APIs write when they follow no standard at all.
+var conventionalErrorMessageNames = []string{
+	"message",
+	"detail",
+	"error_description",
+	"title",
+	"error",
+}
+
+// conventionalMessageFields returns the message properties of an error body that
+// marks none, most specific first. All of them, not just the first: a body
+// carrying the RFC 7807 pair may fill in detail or only title, and which one
+// arrives is a runtime question rather than a generation-time one.
+func conventionalMessageFields(td *ir.TypeDef) []*ir.Field {
+	var fields []*ir.Field
+	for _, name := range conventionalErrorMessageNames {
+		for _, f := range td.Fields {
+			if strings.EqualFold(f.JSONName, name) && isStringField(f) {
+				fields = append(fields, f)
 			}
 		}
 	}
-	return nil
+	return fields
+}
+
+// isStringField reports whether a field holds text that can stand in for the
+// whole body in an error message.
+func isStringField(f *ir.Field) bool {
+	return f.Type == "string" || f.Type == "*string"
 }
 
 // errorType returns the error response type name for an operation, or "".

--- a/internal/templates/errors.go.tmpl
+++ b/internal/templates/errors.go.tmpl
@@ -70,7 +70,7 @@ type {{ .Name }} struct {
 }
 
 func (e *{{ .Name }}) Error() string {
-{{- with errorMessageField $ .Detail }}
+{{- range errorMessageFields $ .Detail }}
 {{- if .IsPointer }}
 	if e.Detail.{{ .Name }} != nil && *e.Detail.{{ .Name }} != "" {
 		return fmt.Sprintf("API error %s: %s", e.statusLabel(), *e.Detail.{{ .Name }})


### PR DESCRIPTION
Closes #67.

`Error()` rendered a readable message only for schemas carrying `x-ms-primary-error-message`. Every other error body, which is nearly all of them, printed its whole JSON:

```
API error 400 Bad Request: {"type":"about:blank","title":"Bad Request","detail":"name is required"}
```

## Conventional names

A schema that marks nothing is read by the names error bodies conventionally use, most specific first:

```
message, detail, error_description, title, error
```

```
API error 400 Bad Request: name is required
```

**Every match is generated, not just the first.** Which property carries the message is a runtime question, not a generation-time one:

```go
func (e *ProblemResponse) Error() string {
	if e.Detail.Detail != nil && *e.Detail.Detail != "" {
		return fmt.Sprintf("API error %s: %s", e.statusLabel(), *e.Detail.Detail)
	}
	if e.Detail.Title != nil && *e.Detail.Title != "" {
		return fmt.Sprintf("API error %s: %s", e.statusLabel(), *e.Detail.Title)
	}
	return e.APIError.Error()
}
```

An RFC 7807 response renders `detail` when it has one and `title` when it does not. My first attempt picked one property at generation time and printed raw JSON for the title-only case, which the tests caught.

The order decides between candidates rather than guessing at them: a body carrying both `detail` and `title` is the RFC 7807 pair, where `detail` is the specific one, and an OAuth body pairs `error` (a code) with `error_description` (the text).

## x-error-message

The Microsoft extension is now joined by a vendor-neutral spelling, so a producer can state this without emitting another toolchain's vocabulary. A marked property wins outright over a conventionally named one, and an empty marked property falls back to the body rather than to a neighbor, since marking one says that is the message.

## What still prints the raw body

- A body with no property that reads as a message.
- A conventional name holding something other than text: `message: {type: integer}` is skipped, and a `detail` beside it is used instead.
- A body that does not parse.

## Tests

`internal/generator/e2e_error_message_names_test.go` compiles and runs: an RFC 7807 body prefers `detail` and falls back to `title`, an OAuth body prefers `error_description` over `error`, a marked property beats a conventionally named one, a non-string `message` is skipped in favor of `detail`, and an empty message still falls back to the body.

One existing test changed meaning: `TestUnannotatedSchemaKeepsBody` asserted that an unannotated schema with a `message` property prints raw JSON, which is what this replaces. It is now two tests: a conventional name is rendered, and a body with no such property keeps the raw output.

`gofmt`, `go vet ./...`, and `go test ./...` pass.