### PR TITLE
fix(analyzer): a multipart body written inline sent its file as base64 text

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -23,6 +23,9 @@ type Analyzer struct {
 	synthesizedByKey map[string]*ir.TypeDef
 	// multipartBodies holds the schema names a multipart request body refers to.
 	multipartBodies map[string]bool
+	// inlineMultipartBodies holds the naming hints of multipart bodies written
+	// inline, which have no schema name to record instead.
+	inlineMultipartBodies map[string]bool
 	// goNameBySchema maps every component schema to its Go type name, filled in
 	// before any conversion so a reference to a schema that has not been converted
 	// yet still resolves to the name it will end up with.
@@ -44,11 +47,12 @@ type Analyzer struct {
 // New creates an Analyzer for the given high-level OpenAPI model.
 func New(model *v3high.Document) *Analyzer {
 	return &Analyzer{
-		model:            model,
-		namer:            naming.NewScope(templates.ReservedIdentifiers...),
-		typesBySchema:    make(map[string]*ir.TypeDef),
-		synthesizedByKey: make(map[string]*ir.TypeDef),
-		goNameBySchema:   make(map[string]string),
+		model:                 model,
+		namer:                 naming.NewScope(templates.ReservedIdentifiers...),
+		typesBySchema:         make(map[string]*ir.TypeDef),
+		synthesizedByKey:      make(map[string]*ir.TypeDef),
+		inlineMultipartBodies: make(map[string]bool),
+		goNameBySchema:        make(map[string]string),
 	}
 }
 

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -70,7 +70,7 @@ func (a *Analyzer) collectMultipartBodySchemas() map[string]bool {
 		return names
 	}
 
-	for _, pathItem := range a.model.Paths.PathItems.FromOldest() {
+	for path, pathItem := range a.model.Paths.PathItems.FromOldest() {
 		for _, m := range pathOperations(pathItem) {
 			if m.op.RequestBody == nil {
 				continue
@@ -79,7 +79,15 @@ func (a *Analyzer) collectMultipartBodySchemas() map[string]bool {
 			if !strings.HasPrefix(contentType, "multipart/") || mediaType == nil || mediaType.Schema == nil {
 				continue
 			}
-			a.markMultipartSchema(names, refToSchemaName(mediaType.Schema.GetReference()), 0)
+			if ref := mediaType.Schema.GetReference(); ref != "" {
+				a.markMultipartSchema(names, refToSchemaName(ref), 0)
+				continue
+			}
+			// An inline body has no schema name to mark, so it is recorded under
+			// the name its synthesized type will be built from. Without this the
+			// body is converted as if it were JSON, and its files go out as
+			// base64 text in ordinary fields.
+			a.inlineMultipartBodies[a.operationName(m.method, path, m.op)+"Body"] = true
 		}
 	}
 	return names

--- a/internal/analyzer/operations_test.go
+++ b/internal/analyzer/operations_test.go
@@ -716,3 +716,75 @@ func TestUnionParam_NamesItsType(t *testing.T) {
 		t.Errorf("shaped type = %+v, want ListItemsShaped", shaped)
 	}
 }
+
+const inlineMultipartAnalyzerSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file: { type: string, format: binary }
+                meta:
+                  type: object
+                  properties:
+                    thumbnail: { type: string, format: binary }
+      responses:
+        "204": { description: ok }
+  /json:
+    post:
+      operationId: sendJSON
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                blob: { type: string, format: binary }
+      responses:
+        "204": { description: ok }
+`
+
+// Multipart is a property of where a schema is used, not of the schema, and an
+// inline body had no name to record that under.
+func TestInlineMultipart_BinaryPropertyBecomesAFilePart(t *testing.T) {
+	_, typeMap := analyzeSpec(t, inlineMultipartAnalyzerSpec)
+
+	body := typeMap["UploadBody"]
+	if body == nil {
+		t.Fatal("UploadBody not found")
+	}
+	fields := map[string]string{}
+	for _, f := range body.Fields {
+		fields[f.JSONName] = f.Type
+	}
+	// Optional here, so a pointer, but a file part either way.
+	if fields["file"] != "*FormFile" {
+		t.Errorf("file = %q, want *FormFile", fields["file"])
+	}
+
+	// A nested object is encoded as JSON, so bytes inside it stay bytes.
+	nested := typeMap["UploadBodyMeta"]
+	if nested == nil {
+		t.Fatal("UploadBodyMeta not found")
+	}
+	if nested.Fields[0].Type != "[]byte" {
+		t.Errorf("nested thumbnail = %q, want []byte", nested.Fields[0].Type)
+	}
+
+	// The same shape sent as JSON keeps byte slices throughout.
+	jsonBody := typeMap["SendJSONBody"]
+	if jsonBody == nil {
+		t.Fatal("SendJSONBody not found")
+	}
+	if jsonBody.Fields[0].Type != "[]byte" {
+		t.Errorf("json blob = %q, want []byte", jsonBody.Fields[0].Type)
+	}
+}

--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -720,6 +720,10 @@ func (a *Analyzer) synthesizeInlineUnion(schema *highbase.Schema, nameHint strin
 // the properties it lists stay typed instead of collapsing into any. Two
 // declarations of one shape share a type.
 func (a *Analyzer) synthesizeInlineObject(schema *highbase.Schema, nameHint string) (string, bool) {
+	// Multipart is a property of where the schema is used, so it is looked up
+	// under the hint the request body passed, before a title renames it.
+	multipartBody := a.inlineMultipartBodies[nameHint]
+
 	// A titled schema names itself, which keeps the generated name stable when
 	// the property that reaches it first is renamed.
 	if schema.Title != "" {
@@ -735,7 +739,7 @@ func (a *Analyzer) synthesizeInlineObject(schema *highbase.Schema, nameHint stri
 	}
 
 	goName := a.namer.Unique(naming.Exported(nameHint))
-	td, err := a.convertObject(goName, schema, false, false)
+	td, err := a.convertObject(goName, schema, false, multipartBody)
 	if err != nil || td == nil {
 		return "", false
 	}

--- a/internal/generator/e2e_inline_multipart_test.go
+++ b/internal/generator/e2e_inline_multipart_test.go
@@ -1,0 +1,160 @@
+package generator
+
+import "testing"
+
+const inlineMultipartSpec = `openapi: 3.1.0
+info: { title: files, version: "1" }
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file: { type: string, format: binary }
+                name: { type: string }
+                meta:
+                  type: object
+                  properties:
+                    thumbnail: { type: string, format: binary }
+              required: [file]
+      responses:
+        "204": { description: ok }
+  /upload-ref:
+    post:
+      operationId: uploadRef
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema: { $ref: "#/components/schemas/UploadForm" }
+      responses:
+        "204": { description: ok }
+components:
+  schemas:
+    UploadForm:
+      type: object
+      properties:
+        file: { type: string, format: binary }
+      required: [file]
+`
+
+// TestE2E_InlineMultipartUpload covers a multipart body written inline. Only a
+// $ref'd body was treated as multipart, so an inline one sent its file as base64
+// text in an ordinary field and no server could read it as an upload.
+func TestE2E_InlineMultipartUpload(t *testing.T) {
+	files, _ := generateFromSpec(t, inlineMultipartSpec, "filesapi")
+
+	runGeneratedWireTest(t, files, "inlinemultipart", `package filesapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type upload struct {
+	filename    string
+	contentType string
+	content     string
+	fields      map[string]string
+}
+
+func serve(t *testing.T) (*Client, *upload) {
+	t.Helper()
+	got := &upload{fields: map[string]string{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("ParseMultipartForm: %v", err)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		for k, v := range r.MultipartForm.Value {
+			got.fields[k] = v[0]
+		}
+		f, hdr, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("FormFile: %v", err)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		defer f.Close()
+		got.filename = hdr.Filename
+		got.contentType = hdr.Header.Get("Content-Type")
+		b, _ := io.ReadAll(f)
+		got.content = string(b)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL), got
+}
+
+func TestInlineBodyUploadsAFile(t *testing.T) {
+	client, got := serve(t)
+
+	name := "readme"
+	err := client.Upload(t.Context(), UploadBody{
+		File: FormFile{Filename: "a.txt", ContentType: "text/plain", Content: []byte("hello")},
+		Name: &name,
+	})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+
+	if got.filename != "a.txt" || got.content != "hello" {
+		t.Errorf("upload arrived as filename=%q content=%q", got.filename, got.content)
+	}
+	if got.contentType != "text/plain" {
+		t.Errorf("part Content-Type = %q, want text/plain", got.contentType)
+	}
+	if got.fields["name"] != "readme" {
+		t.Errorf("name field = %q", got.fields["name"])
+	}
+}
+
+// A binary property nested inside the body is not a part of its own: the object
+// holding it is encoded as JSON, so the bytes stay base64 there.
+func TestNestedBinaryStaysEncoded(t *testing.T) {
+	client, got := serve(t)
+
+	err := client.Upload(t.Context(), UploadBody{
+		File: FormFile{Filename: "a.txt", Content: []byte("hello")},
+		Meta: &UploadBodyMeta{Thumbnail: []byte("thumb")},
+	})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+
+	var meta struct {
+		Thumbnail []byte `+"`"+`json:"thumbnail"`+"`"+`
+	}
+	if err := json.Unmarshal([]byte(got.fields["meta"]), &meta); err != nil {
+		t.Fatalf("meta part was not JSON: %q: %v", got.fields["meta"], err)
+	}
+	if string(meta.Thumbnail) != "thumb" {
+		t.Errorf("nested bytes = %q, want thumb", meta.Thumbnail)
+	}
+}
+
+// The $ref'd form keeps working exactly as before.
+func TestRefBodyStillUploads(t *testing.T) {
+	client, got := serve(t)
+
+	err := client.UploadRef(t.Context(), UploadForm{
+		File: FormFile{Filename: "b.txt", Content: []byte("world")},
+	})
+	if err != nil {
+		t.Fatalf("UploadRef: %v", err)
+	}
+	if got.filename != "b.txt" || got.content != "world" {
+		t.Errorf("upload arrived as filename=%q content=%q", got.filename, got.content)
+	}
+}
+`)
+}


### PR DESCRIPTION
Closes #90.

File uploads worked only when the multipart body was a `$ref`. Declared inline, the file went out as base64 text in an ordinary field:

```
server FormFile error: http: no such file
server saw filename="" value="aGVsbG8="
```

No inline-declared upload worked, and nothing said so.

## Cause

`collectMultipartBodySchemas` marks bodies by schema name:

```go
a.markMultipartSchema(names, refToSchemaName(mediaType.Schema.GetReference()), 0)
```

An inline body has no reference and therefore no name to mark, so `convertObject` ran without `multipartBody`, `format: binary` resolved to `[]byte`, and the encoder did what a byte slice means everywhere else in OpenAPI: `format: byte`, written as base64 with `WriteField`. The encoder's assumption was right; the body was never told it was multipart.

Worth noting this became reachable in #80. Before inline objects were typed at all, an inline multipart body was `any`.

## Fix

Inline bodies are recorded under the name their synthesized type is built from, so they convert with the multipart handling a `$ref`'d body already had:

```go
File FormFile `json:"file"`   // was []byte
```

Two details:

- **Looked up before a title renames the type.** A titled inline schema names itself, so the multipart lookup uses the hint the request body passed rather than the final name.
- **Nested binary properties stay `[]byte`.** An object property of a multipart body is encoded as JSON, where bytes are base64 rather than a part of their own, so the multipart handling applies to the body's own properties and no deeper.

## Tests

- `internal/analyzer/operations_test.go`: an inline multipart body's binary property becomes a file part, a binary nested one property deeper stays `[]byte`, and the same shape sent as JSON keeps byte slices throughout.
- `internal/generator/e2e_inline_multipart_test.go`: compiles and runs against an `httptest` server that parses the form, checking `r.FormFile` returns the file with its filename and per-part content type, a sibling text field still arrives, a nested binary arrives base64 inside the JSON part, and the `$ref`'d form still uploads.

`gofmt`, `go vet ./...`, and `go test ./...` pass.