### PR TITLE
feat(generator): offset and page pagination get the iterator they were detected for

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Given any OpenAPI 3.1 (or 3.0) spec, it outputs a complete, idiomatic Go client 
 - **Response headers**: status and headers captured through the context, with declared headers parsed per operation
 - **Authentication** — `AuthProvider` interface with built-in Bearer, API key, and Basic auth
 - **Error handling** — `APIError` with sentinel errors (`errors.Is`), typed error wrappers with parsed response bodies (`errors.As`), readable messages via `x-ms-primary-error-message`
-- **Pagination** — auto-detected cursor/offset pagination with generic `PageIterator[T]`
+- **Pagination**: auto-detected cursor, offset, and page pagination with a generic `PageIterator[T]`
 - **Retries** — configurable exponential backoff with jitter and `Retry-After` header support
 - **Middleware** — composable request/response middleware chain
 - **OpenAPI 3.1**: JSON Schema 2020-12, nullable type arrays, `$ref` resolution ([what is not generated](#not-supported))

--- a/internal/analyzer/pagination.go
+++ b/internal/analyzer/pagination.go
@@ -98,7 +98,7 @@ func (a *Analyzer) detectOffsetPagination(op *ir.OperationDef, pkg *ir.Package) 
 		limitParam = orig
 	}
 	if offsetParam != "" && limitParam != "" {
-		return a.buildOffsetPagination(op, pkg, offsetParam, limitParam)
+		return a.buildOffsetPagination(op, pkg, ir.PaginationStyleOffset, offsetParam, limitParam)
 	}
 
 	// Check for page + (per_page | page_size | pageSize | limit) pattern.
@@ -112,15 +112,17 @@ func (a *Analyzer) detectOffsetPagination(op *ir.OperationDef, pkg *ir.Package) 
 
 	for _, name := range []string{"per_page", "page_size", "pagesize", "limit"} {
 		if orig, ok := queryNames[name]; ok {
-			return a.buildOffsetPagination(op, pkg, pageParam, orig)
+			return a.buildOffsetPagination(op, pkg, ir.PaginationStylePage, pageParam, orig)
 		}
 	}
 
 	return nil
 }
 
-// buildOffsetPagination builds an offset-style PaginationDef.
-func (a *Analyzer) buildOffsetPagination(op *ir.OperationDef, pkg *ir.Package, offsetParam, limitParam string) *ir.PaginationDef {
+// buildOffsetPagination builds a PaginationDef for the styles that count rather
+// than follow a cursor. The style decides how the parameter advances: an offset
+// by the items received, a page by one.
+func (a *Analyzer) buildOffsetPagination(op *ir.OperationDef, pkg *ir.Package, style ir.PaginationStyle, offsetParam, limitParam string) *ir.PaginationDef {
 	respType := a.findSuccessResponseType(op, pkg)
 	if respType == nil {
 		return nil
@@ -131,7 +133,7 @@ func (a *Analyzer) buildOffsetPagination(op *ir.OperationDef, pkg *ir.Package, o
 	}
 
 	return &ir.PaginationDef{
-		Style:       ir.PaginationStyleOffset,
+		Style:       style,
 		OffsetParam: offsetParam,
 		LimitParam:  limitParam,
 		ItemsField:  items.name,

--- a/internal/analyzer/pagination_test.go
+++ b/internal/analyzer/pagination_test.go
@@ -166,8 +166,9 @@ func TestPagination_PageBasedDetection(t *testing.T) {
 	if op.Pagination == nil {
 		t.Fatal("ListResults.Pagination should not be nil")
 	}
-	if op.Pagination.Style != ir.PaginationStyleOffset {
-		t.Errorf("ListResults.Pagination.Style = %v, want PaginationStyleOffset", op.Pagination.Style)
+	// page and per_page count pages, not items, so they advance by one.
+	if op.Pagination.Style != ir.PaginationStylePage {
+		t.Errorf("ListResults.Pagination.Style = %v, want PaginationStylePage", op.Pagination.Style)
 	}
 	if op.Pagination.OffsetParam != "page" {
 		t.Errorf("ListResults.Pagination.OffsetParam = %q, want %q", op.Pagination.OffsetParam, "page")

--- a/internal/generator/e2e_offset_pagination_test.go
+++ b/internal/generator/e2e_offset_pagination_test.go
@@ -1,0 +1,151 @@
+package generator
+
+import "testing"
+
+const offsetPaginationSpec = `openapi: 3.1.0
+info: { title: pag, version: "1" }
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - { name: offset, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+  /results:
+    get:
+      operationId: listResults
+      parameters:
+        - { name: page, in: query, schema: { type: integer } }
+        - { name: per_page, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+components:
+  schemas:
+    Page:
+      type: object
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/Item" } }
+        total: { type: integer }
+    Item:
+      type: object
+      properties:
+        id: { type: string }
+`
+
+// TestE2E_OffsetAndPageIterators covers the two counting styles. Both were
+// detected and neither generated an iterator, so the package exported
+// PageIterator[T] with no method returning one.
+func TestE2E_OffsetAndPageIterators(t *testing.T) {
+	files, _ := generateFromSpec(t, offsetPaginationSpec, "pagapi")
+
+	runGeneratedWireTest(t, files, "offsetpagination", `package pagapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// pages serves items keyed by the value of param, and records what was asked for.
+func pages(t *testing.T, param string, byValue map[string][]string) (*Client, *[]string) {
+	t.Helper()
+	var asked []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		value := r.URL.Query().Get(param)
+		asked = append(asked, value)
+		items := []map[string]string{}
+		for _, id := range byValue[value] {
+			items = append(items, map[string]string{"id": id})
+		}
+		json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL), &asked
+}
+
+// An offset advances by the number of items received.
+func TestOffsetIteratorCountsItems(t *testing.T) {
+	client, asked := pages(t, "offset", map[string][]string{
+		"":  {"a", "b"},
+		"2": {"c"},
+		"3": {},
+	})
+
+	all, err := client.ListItemsIter(t.Context()).All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 3 || all[0].ID == nil || *all[0].ID != "a" || *all[2].ID != "c" {
+		t.Errorf("items = %+v, want a, b, c", all)
+	}
+	if len(*asked) != 3 || (*asked)[1] != "2" || (*asked)[2] != "3" {
+		t.Errorf("offsets requested = %v, want the first page, then 2, then 3", *asked)
+	}
+}
+
+// A page number advances by one, whatever a page holds.
+func TestPageIteratorCountsPages(t *testing.T) {
+	client, asked := pages(t, "page", map[string][]string{
+		"":  {"a", "b"},
+		"2": {"c", "d"},
+		"3": {},
+	})
+
+	all, err := client.ListResultsIter(t.Context()).All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 4 {
+		t.Errorf("items = %d, want 4", len(all))
+	}
+	if len(*asked) != 3 || (*asked)[1] != "2" || (*asked)[2] != "3" {
+		t.Errorf("pages requested = %v, want the first page, then 2, then 3", *asked)
+	}
+}
+
+// A caller who points the iterator at a starting offset gets a walk that
+// continues from there, rather than one that resets to the beginning on the
+// second page.
+func TestCallerStartIsHonoredAndContinued(t *testing.T) {
+	client, asked := pages(t, "offset", map[string][]string{
+		"10": {"k", "l"},
+		"12": {"m"},
+		"13": {},
+	})
+
+	start := int64(10)
+	all, err := client.ListItemsIter(t.Context(), ListItemsParams{Offset: &start}).All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("items = %d, want 3", len(all))
+	}
+	if len(*asked) != 3 || (*asked)[0] != "10" || (*asked)[1] != "12" || (*asked)[2] != "13" {
+		t.Errorf("offsets requested = %v, want 10, then 12, then 13", *asked)
+	}
+}
+
+// An empty first page ends the walk rather than repeating it.
+func TestEmptyFirstPageStops(t *testing.T) {
+	client, asked := pages(t, "offset", map[string][]string{"": {}})
+
+	all, err := client.ListItemsIter(t.Context()).All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 0 || len(*asked) != 1 {
+		t.Errorf("items = %d after %v, want none after one request", len(all), *asked)
+	}
+}
+`)
+}

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -48,6 +48,10 @@ func FuncMap() template.FuncMap {
 		"hasPaginatedOps":         hasPaginatedOps,
 		"paginationItemType":      paginationItemType,
 		"paginationCursorField":   paginationCursorField,
+		"paginationOffsetParam":   paginationOffsetParam,
+		"paginationStart":         paginationStart,
+		"paramElemType":           paramElemType,
+		"hasPrefix":               strings.HasPrefix,
 		"toGoName":                naming.Exported,
 		"uniqueErrorTypes":        uniqueErrorTypes,
 		"errorMessageFields":      errorMessageFields,
@@ -759,6 +763,35 @@ func paginationCursorField(op *ir.OperationDef) string {
 		}
 	}
 	return naming.Exported(op.Pagination.CursorParam)
+}
+
+// paginationOffsetParam returns the parameter an offset or page iterator
+// advances, so the iterator can assign to it in the type the spec gave it.
+func paginationOffsetParam(op *ir.OperationDef) *ir.ParamDef {
+	if op.Pagination == nil {
+		return nil
+	}
+	for _, p := range op.QueryParams {
+		if p.OrigName == op.Pagination.OffsetParam {
+			return p
+		}
+	}
+	return nil
+}
+
+// paginationStart returns the value the advancing parameter begins at: an offset
+// counts from zero, a page number from one.
+func paginationStart(style ir.PaginationStyle) string {
+	if style == ir.PaginationStylePage {
+		return "int64(1)"
+	}
+	return "int64(0)"
+}
+
+// paramElemType returns a parameter's type with any pointer stripped, which is
+// what a value assigned to it has to be built as.
+func paramElemType(p *ir.ParamDef) string {
+	return strings.TrimPrefix(p.Type, "*")
 }
 
 // uniqueErrorTypes returns deduplicated error response type names from all operations.

--- a/internal/ir/pagination.go
+++ b/internal/ir/pagination.go
@@ -5,7 +5,10 @@ type PaginationStyle int
 
 const (
 	PaginationStyleCursor PaginationStyle = iota
+	// PaginationStyleOffset advances by the number of items received.
 	PaginationStyleOffset
+	// PaginationStylePage advances by one page, whatever a page holds.
+	PaginationStylePage
 )
 
 // PaginationDef describes pagination for an operation.
@@ -14,7 +17,8 @@ type PaginationDef struct {
 	// For cursor-based:
 	CursorParam string // Query param name for the cursor
 	CursorField string // Response field containing next cursor
-	// For offset-based:
+	// For offset-based and page-based: the parameter that advances, and the one
+	// that sizes a page.
 	OffsetParam string
 	LimitParam  string
 	// Common:

--- a/internal/templates/pagination.go.tmpl
+++ b/internal/templates/pagination.go.tmpl
@@ -64,8 +64,9 @@ func (it *PageIterator[T]) ForEach(fn func(T) error) error {
 		}
 	}
 }
-{{ range .Operations }}{{ if .Pagination }}{{ if eq .Pagination.Style 0 }}
+{{ range .Operations }}{{ $op := . }}{{ if .Pagination }}
 {{- $hasReqParam := or (hasRequiredQueryParams .) (hasRequiredHeaderParams .) (hasRequiredCookieParams .) }}
+{{- if eq .Pagination.Style 0 }}
 // {{ .Name }}Iter returns an iterator over paginated {{ .Name }} results.
 func (c *Client) {{ .Name }}Iter(ctx context.Context{{ range .PathParams }}, {{ .Name }} {{ .Type }}{{ end }}{{ if hasBody . }}, body {{ if .RequestBody }}{{ if not .RequestBody.Required }}*{{ end }}{{ .RequestBody.TypeName }}{{ else }}any{{ end }}{{ end }}{{ if $hasReqParam }}, params {{ .Name }}Params{{ else }}, opts ...{{ .Name }}Params{{ end }}) *PageIterator[{{ paginationItemType . }}] {
 	return &PageIterator[{{ paginationItemType . }}]{
@@ -90,5 +91,50 @@ func (c *Client) {{ .Name }}Iter(ctx context.Context{{ range .PathParams }}, {{ 
 		},
 	}
 }
-{{ end }}{{ end }}{{ end }}
+{{ else }}{{ with $offset := paginationOffsetParam $op }}
+// {{ $op.Name }}Iter returns an iterator over paginated {{ $op.Name }} results.
+// It advances {{ $offset.OrigName }} {{ if eq $op.Pagination.Style 1 }}by the number of items each page returns{{ else }}one page at a time{{ end }},
+// and stops on the first page that comes back empty.
+func (c *Client) {{ $op.Name }}Iter(ctx context.Context{{ range $op.PathParams }}, {{ .Name }} {{ .Type }}{{ end }}{{ if hasBody $op }}, body {{ if $op.RequestBody }}{{ if not $op.RequestBody.Required }}*{{ end }}{{ $op.RequestBody.TypeName }}{{ else }}any{{ end }}{{ end }}{{ if $hasReqParam }}, params {{ $op.Name }}Params{{ else }}, opts ...{{ $op.Name }}Params{{ end }}) *PageIterator[{{ paginationItemType $op }}] {
+	return &PageIterator[{{ paginationItemType $op }}]{
+		fetch: func(cursor string) ([]{{ paginationItemType $op }}, string, error) {
+			{{ if $hasReqParam }}p := params
+			{{ else }}p := {{ $op.Name }}Params{}
+			if len(opts) > 0 {
+				p = opts[0]
+			}
+			{{ end }}// Where the iterator has reached rides in the cursor. The first page
+			// starts wherever the caller pointed it, so walking on from there
+			// counts from that point rather than from the beginning.
+			at := {{ paginationStart $op.Pagination.Style }}
+{{- if hasPrefix (paramType $offset) "*" }}
+			if p.{{ $offset.FieldName }} != nil {
+				at = int64(*p.{{ $offset.FieldName }})
+			}
+{{- else }}
+			at = int64(p.{{ $offset.FieldName }})
+{{- end }}
+			if cursor != "" {
+				parsed, err := strconv.ParseInt(cursor, 10, 64)
+				if err != nil {
+					return nil, "", fmt.Errorf("reading the {{ $offset.OrigName }} to fetch: %w", err)
+				}
+				at = parsed
+				next := {{ paramElemType $offset }}(at)
+				p.{{ $offset.FieldName }} = {{ if hasPrefix (paramType $offset) "*" }}&next{{ else }}next{{ end }}
+			}
+
+			result, err := c.{{ $op.Name }}(ctx{{ range $op.PathParams }}, {{ .Name }}{{ end }}{{ if hasBody $op }}, body{{ end }}, p)
+			if err != nil {
+				return nil, "", err
+			}
+			items := result.{{ toGoName $op.Pagination.ItemsField }}
+			if len(items) == 0 {
+				return items, "", nil
+			}
+			return items, strconv.FormatInt(at+{{ if eq $op.Pagination.Style 1 }}int64(len(items)){{ else }}1{{ end }}, 10), nil
+		},
+	}
+}
+{{ end }}{{ end }}{{ end }}{{ end }}
 {{ end }}


### PR DESCRIPTION
Closes #92.

The README advertises "auto-detected cursor/offset pagination". Detection worked; generation did not:

```
{{ range .Operations }}{{ if .Pagination }}{{ if eq .Pagination.Style 0 }}
```

`PaginationStyleOffset` never matched. An offset or page spec got a `pagination.go` containing `PageIterator[T]` and no method returning one, so everything the analyzer worked out was computed and discarded.


The IR conflated them: `buildOffsetPagination` served both `offset`/`limit` and `page`/`per_page`, storing the page parameter in `OffsetParam`. They advance differently, so one generated rule would page wrongly for whichever it was not written for:

- **Offset** advances by the number of items the page returned.
- **Page** advances by one, whatever a page holds.

`PaginationStylePage` now separates them. A walk ends on the first empty page: a `total` property could stop it one request earlier, but it is neither always present nor always right, while an empty page is unambiguous.

## One iterator type

Where the iterator has reached rides in the existing cursor string as a formatted number, so no second exported iterator appears, and the number strictly increases, which satisfies the non-advancing-cursor guard from #65 without special-casing.

## Tests

- `internal/analyzer/pagination_test.go`: the page-based spec now expects `PaginationStylePage`, since `page`/`per_page` count pages rather than items.
- `internal/generator/e2e_offset_pagination_test.go`: compiles and runs both iterators against `httptest`, asserting an offset walk requests the first page then 2 then 3 while a page walk requests the first page then 2 then 3 for pages of two items, that a caller's starting offset is honored and continued, and that an empty first page ends the walk after one request.

`gofmt`, `go vet ./...`, and `go test ./...` pass.