### PR TITLE
fix(generator): Retry-After was read in one form and obeyed without limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Given any OpenAPI 3.1 (or 3.0) spec, it outputs a complete, idiomatic Go client 
 - **Authentication** — `AuthProvider` interface with built-in Bearer, API key, and Basic auth
 - **Error handling** — `APIError` with sentinel errors (`errors.Is`), typed error wrappers with parsed response bodies (`errors.As`), readable messages via `x-ms-primary-error-message`
 - **Pagination**: auto-detected cursor, offset, and page pagination with a generic `PageIterator[T]`
-- **Retries** — configurable exponential backoff with jitter and `Retry-After` header support
+- **Retries**: configurable exponential backoff with jitter, honoring `Retry-After` in both forms and declining a wait past `MaxDelay`
 - **Middleware** — composable request/response middleware chain
 - **OpenAPI 3.1**: JSON Schema 2020-12, nullable type arrays, `$ref` resolution ([what is not generated](#not-supported))
 

--- a/internal/generator/e2e_retry_after_test.go
+++ b/internal/generator/e2e_retry_after_test.go
@@ -1,0 +1,132 @@
+package generator
+
+import "testing"
+
+const retryAfterSpec = `openapi: 3.1.0
+info: { title: rate, version: "1" }
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { type: string } }
+`
+
+// TestE2E_RetryAfter covers both forms of the header and the wait a client did
+// not agree to: a date was ignored entirely, and a long delta blocked the call
+// for its full length regardless of MaxDelay.
+func TestE2E_RetryAfter(t *testing.T) {
+	files, _ := generateFromSpec(t, retryAfterSpec, "rateapi")
+
+	runGeneratedWireTest(t, files, "retryafter", `package rateapi
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// limited answers 429 with the given Retry-After until the last attempt.
+func limited(t *testing.T, header string, failures int) (*Client, *int) {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls <= failures {
+			w.Header().Set("Retry-After", header)
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`+"`"+`"ok"`+"`"+`))
+	}))
+	t.Cleanup(srv.Close)
+	cfg := DefaultRetryConfig()
+	cfg.BaseDelay = 10 * time.Millisecond
+	cfg.MaxDelay = 5 * time.Second
+	return NewClient(srv.URL, WithRetry(cfg)), &calls
+}
+
+func TestDeltaSecondsIsHonored(t *testing.T) {
+	client, calls := limited(t, "1", 1)
+
+	start := time.Now()
+	got, err := client.GetThing(t.Context())
+	if err != nil {
+		t.Fatalf("GetThing: %v", err)
+	}
+	if got == nil || *got != "ok" {
+		t.Errorf("result = %v", got)
+	}
+	if *calls != 2 {
+		t.Errorf("calls = %d, want a retry", *calls)
+	}
+	if waited := time.Since(start); waited < time.Second {
+		t.Errorf("waited %v, want at least the second the server asked for", waited)
+	}
+}
+
+// The date form is the other half of RFC 9110, and was falling through to
+// backoff, which retries sooner than the server allowed.
+func TestHTTPDateIsHonored(t *testing.T) {
+	// HTTP dates carry whole seconds, so asking for two guarantees at least one
+	// survives the truncation.
+	client, calls := limited(t, time.Now().Add(2*time.Second).UTC().Format(http.TimeFormat), 1)
+
+	start := time.Now()
+	if _, err := client.GetThing(t.Context()); err != nil {
+		t.Fatalf("GetThing: %v", err)
+	}
+	if *calls != 2 {
+		t.Errorf("calls = %d, want a retry", *calls)
+	}
+	if waited := time.Since(start); waited < time.Second {
+		t.Errorf("waited %v, want the client to respect the date it was given", waited)
+	}
+}
+
+// A wait past MaxDelay is not something the caller agreed to, so the call
+// returns rather than sleeping it out.
+func TestWaitBeyondMaxDelayGivesUp(t *testing.T) {
+	client, calls := limited(t, "3600", 5)
+
+	start := time.Now()
+	_, err := client.GetThing(t.Context())
+	if err == nil {
+		t.Fatal("expected the rate limit error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("err = %v, want the 429", err)
+	}
+	if *calls != 1 {
+		t.Errorf("calls = %d, want no retry", *calls)
+	}
+	if waited := time.Since(start); waited > 2*time.Second {
+		t.Errorf("waited %v, want the call to return rather than sleep", waited)
+	}
+
+	// The header is still on the response, so the caller can schedule it.
+	if apiErr.Status == "" {
+		t.Error("the error should carry the response status")
+	}
+}
+
+// A retryable status with no Retry-After still backs off as before.
+func TestNoHeaderStillBacksOff(t *testing.T) {
+	client, calls := limited(t, "", 1)
+
+	if _, err := client.GetThing(t.Context()); err != nil {
+		t.Fatalf("GetThing: %v", err)
+	}
+	if *calls != 2 {
+		t.Errorf("calls = %d, want a retry", *calls)
+	}
+}
+`)
+}

--- a/internal/templates/client.go.tmpl
+++ b/internal/templates/client.go.tmpl
@@ -163,7 +163,7 @@ func (c *Client) do(ctx context.Context, method string, path string, body any, c
 		}
 
 		// Check if we should retry.
-		if c.retryConfig != nil && attempt < maxAttempts-1 && shouldRetryStatus(method, resp.StatusCode, *c.retryConfig) {
+		if c.retryConfig != nil && attempt < maxAttempts-1 && shouldRetryStatus(method, resp.StatusCode, *c.retryConfig) && withinRetryBudget(resp, *c.retryConfig) {
 			delay := retryDelay(attempt, *c.retryConfig, resp)
 			timer := time.NewTimer(delay)
 			select {

--- a/internal/templates/retry.go.tmpl
+++ b/internal/templates/retry.go.tmpl
@@ -75,13 +75,8 @@ func shouldRetryStatus(method string, statusCode int, cfg RetryConfig) bool {
 
 // retryDelay calculates delay with exponential backoff, jitter, and Retry-After support.
 func retryDelay(attempt int, cfg RetryConfig, resp *http.Response) time.Duration {
-	// Check Retry-After header first.
-	if resp != nil {
-		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			if seconds, err := strconv.Atoi(ra); err == nil && seconds > 0 {
-				return time.Duration(seconds) * time.Second
-			}
-		}
+	if wait, ok := retryAfter(resp); ok {
+		return wait
 	}
 
 	// Exponential backoff with jitter.
@@ -95,6 +90,40 @@ func retryDelay(attempt int, cfg RetryConfig, resp *http.Response) time.Duration
 	delay = (delay + jitter) / 2
 
 	return time.Duration(delay)
+}
+
+// retryAfter returns the wait a response asks for, in either form RFC 9110
+// allows, and whether it asked at all. A zero wait is an instruction like any
+// other: retry now.
+func retryAfter(resp *http.Response) (time.Duration, bool) {
+	if resp == nil {
+		return 0, false
+	}
+	raw := resp.Header.Get("Retry-After")
+	if raw == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(raw); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	if at, err := http.ParseTime(raw); err == nil {
+		// A date already in the past says retry now, not retry in the past.
+		return max(time.Until(at), 0), true
+	}
+	return 0, false
+}
+
+// withinRetryBudget reports whether waiting as long as the response asks for is
+// something this client agreed to. A wait past MaxDelay is not capped, since
+// retrying sooner than a server asked is what the header exists to prevent: the
+// call returns its error instead, leaving the caller to schedule the work with
+// the header in hand.
+func withinRetryBudget(resp *http.Response, cfg RetryConfig) bool {
+	wait, ok := retryAfter(resp)
+	return !ok || wait <= cfg.MaxDelay
 }
 
 // isIdempotentMethod reports whether method is safe to retry after a transient network error (POST is not).


### PR DESCRIPTION
Closes #94.

## An HTTP-date Retry-After was ignored

RFC 9110 allows two forms. Only delta-seconds was parsed:

```
Retry-After: Wed, 20 Aug 2026 19:15:00 GMT   (5 seconds out)
retryDelay -> 948ms
```

Told to wait five seconds, the client retried in under one. That is what turns a rate limit into a longer one, and the date form is what several large APIs send.

`Retry-After: 0` was dropped as well, since the check demanded `seconds > 0`. Zero is an instruction: retry now.

## A long Retry-After blocked for its full length

The value became the delay with no ceiling, while `RetryConfig.MaxDelay` exists and defaults to 30 seconds:

```
MaxDelay   = 30s
Retry-After: 3600
retryDelay -> 1h0m0s
```

An hour-long sleep inside an ordinary method call, breakable only by cancelling the context.

**Capping at `MaxDelay` would be the wrong fix**, since retrying sooner than the server allowed is exactly what the header exists to prevent. The retries end instead: the call returns its `APIError`, and the caller reads the header off the response (`ResponseMeta` from #70 makes that a one-liner) and schedules the work themselves. That is their decision, not the library's.

## Tests

`internal/generator/e2e_retry_after_test.go` compiles and runs against `httptest`: a delta-seconds header is waited out and the call succeeds on retry, a date header is honored rather than backed off (asking for two seconds, since HTTP dates carry whole seconds and one would be truncated away), a 3600 second ask returns the 429 without retrying and without sleeping, and a retryable status with no header still backs off as before.

`gofmt`, `go vet ./...`, and `go test ./...` pass.