### PR TITLE
fix(analyzer): two properties that sanitize to one Go name broke the build

### DIFF
--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -192,7 +192,7 @@ func (a *Analyzer) convertAllOf(goName string, schema *highbase.Schema, nullable
 		if refName != "" {
 			// $ref to a known component schema: add as embedded field.
 			goTypeName := a.goTypeForSchemaName(refName)
-			td.Fields = append(td.Fields, &ir.Field{
+			td.Fields = addField(td.Fields, &ir.Field{
 				Name:     goTypeName,
 				Type:     goTypeName,
 				Embedded: true,
@@ -227,7 +227,7 @@ func (a *Analyzer) convertAllOf(goName string, schema *highbase.Schema, nullable
 				continue
 			}
 
-			td.Fields = append(td.Fields, a.convertProperty(goName, propName, propSchema, requiredSet[propName], multipartBody))
+			td.Fields = addField(td.Fields, a.convertProperty(goName, propName, propSchema, requiredSet[propName], multipartBody))
 		}
 	}
 
@@ -429,7 +429,7 @@ func (a *Analyzer) convertObject(goName string, schema *highbase.Schema, nullabl
 			continue
 		}
 
-		td.Fields = append(td.Fields, a.convertProperty(goName, propName, propSchema, requiredSet[propName], multipartBody))
+		td.Fields = addField(td.Fields, a.convertProperty(goName, propName, propSchema, requiredSet[propName], multipartBody))
 	}
 
 	// The generator gives a struct with a catch-all MarshalJSON/UnmarshalJSON so
@@ -472,14 +472,29 @@ func (a *Analyzer) patternPropertiesType(schema *highbase.Schema, nameHint strin
 // catchAllFieldName picks a Go name for the synthetic additionalProperties field
 // that no declared property has already taken.
 func catchAllFieldName(fields []*ir.Field) string {
-	name := "AdditionalProperties"
+	return uniqueFieldName(fields, "AdditionalProperties")
+}
+
+// addField appends a field under a name no other field in the struct holds. Two
+// properties can differ on the wire and still normalize to one Go identifier,
+// which the compiler rejects as a redeclaration; the JSON tag is untouched, so
+// only the Go name moves.
+func addField(fields []*ir.Field, f *ir.Field) []*ir.Field {
+	f.Name = uniqueFieldName(fields, f.Name)
+	return append(fields, f)
+}
+
+// uniqueFieldName returns name, or the first numbered variant of it that the
+// struct does not already declare.
+func uniqueFieldName(fields []*ir.Field, name string) string {
 	taken := func(candidate string) bool {
 		return slices.ContainsFunc(fields, func(f *ir.Field) bool { return f.Name == candidate })
 	}
-	for i := 2; taken(name); i++ {
-		name = "AdditionalProperties" + strconv.Itoa(i)
+	candidate := name
+	for i := 2; taken(candidate); i++ {
+		candidate = name + strconv.Itoa(i)
 	}
-	return name
+	return candidate
 }
 
 // formFileType returns the Go type for a multipart property carrying file content.

--- a/internal/analyzer/schemas_field_collision_test.go
+++ b/internal/analyzer/schemas_field_collision_test.go
@@ -1,0 +1,103 @@
+package analyzer
+
+import "testing"
+
+const fieldCollisionSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        user-id: { type: string }
+        user_id: { type: string }
+        userId: { type: string }
+        keep: { type: string }
+    Composed:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+        - type: object
+          properties:
+            base: { type: string }
+    Base:
+      type: object
+      properties:
+        id: { type: string }
+    Bagged:
+      type: object
+      properties:
+        additionalProperties: { type: string }
+      additionalProperties: { type: integer }
+`
+
+// Property names that differ on the wire can normalize to one Go identifier,
+// which the compiler rejects as a redeclaration.
+func TestFieldNames_CollisionsAreNumbered(t *testing.T) {
+	_, typeMap := analyzeSpec(t, fieldCollisionSpec)
+
+	thing := typeMap["Thing"]
+	if thing == nil {
+		t.Fatal("Thing not found")
+	}
+	var names, tags []string
+	for _, f := range thing.Fields {
+		names = append(names, f.Name)
+		tags = append(tags, f.JSONName)
+	}
+	want := []string{"UserID", "UserID2", "UserID3", "Keep"}
+	if len(names) != len(want) {
+		t.Fatalf("fields = %v, want %v", names, want)
+	}
+	for i, w := range want {
+		if names[i] != w {
+			t.Errorf("field %d = %q, want %q", i, names[i], w)
+		}
+	}
+	// Only the Go name moves; each field keeps the property it came from.
+	wantTags := []string{"user-id", "user_id", "userId", "keep"}
+	for i, w := range wantTags {
+		if tags[i] != w {
+			t.Errorf("field %d tag = %q, want %q", i, tags[i], w)
+		}
+	}
+}
+
+// An embedded type from allOf shares the struct's namespace with the properties
+// merged beside it.
+func TestFieldNames_EmbeddedTypeCollidesWithAProperty(t *testing.T) {
+	_, typeMap := analyzeSpec(t, fieldCollisionSpec)
+
+	composed := typeMap["Composed"]
+	if composed == nil {
+		t.Fatal("Composed not found")
+	}
+	if len(composed.Fields) != 2 {
+		t.Fatalf("fields = %+v, want the embed and the property", composed.Fields)
+	}
+	if composed.Fields[0].Name != "Base" || !composed.Fields[0].Embedded {
+		t.Errorf("field 0 = %+v, want the embedded Base", composed.Fields[0])
+	}
+	if composed.Fields[1].Name != "Base2" {
+		t.Errorf("field 1 = %q, want Base2", composed.Fields[1].Name)
+	}
+}
+
+// The synthetic catch-all is subject to the same rule, from the other side.
+func TestFieldNames_CatchAllAvoidsADeclaredProperty(t *testing.T) {
+	_, typeMap := analyzeSpec(t, fieldCollisionSpec)
+
+	bagged := typeMap["Bagged"]
+	if bagged == nil {
+		t.Fatal("Bagged not found")
+	}
+	if len(bagged.Fields) != 2 {
+		t.Fatalf("fields = %+v, want the property and the catch-all", bagged.Fields)
+	}
+	if bagged.Fields[0].Name != "AdditionalProperties" || bagged.Fields[1].Name != "AdditionalProperties2" {
+		t.Errorf("fields = %q, %q", bagged.Fields[0].Name, bagged.Fields[1].Name)
+	}
+	if !bagged.Fields[1].CatchAll {
+		t.Error("the second field should be the catch-all")
+	}
+}

--- a/internal/generator/e2e_field_collision_test.go
+++ b/internal/generator/e2e_field_collision_test.go
@@ -1,0 +1,68 @@
+package generator
+
+import "testing"
+
+const fieldCollisionAPISpec = `openapi: 3.1.0
+info: { title: coll, version: "1" }
+paths:
+  /things:
+    get:
+      operationId: getThing
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Thing" } }
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        user-id: { type: string }
+        user_id: { type: string }
+        userId: { type: string }
+      required: [user-id, user_id, userId]
+`
+
+// TestE2E_CollidingPropertyNames covers property names that differ on the wire
+// and normalize to one Go identifier. The struct redeclared the field, so the
+// whole generated package failed to compile.
+func TestE2E_CollidingPropertyNames(t *testing.T) {
+	files, _ := generateFromSpec(t, fieldCollisionAPISpec, "collapi")
+
+	runGeneratedWireTest(t, files, "fieldcollision", `package collapi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Each field still carries the property it came from, so a payload that uses
+// all three round-trips with them kept apart.
+func TestCollidingPropertiesStayDistinct(t *testing.T) {
+	var thing Thing
+	payload := `+"`"+`{"user-id":"dash","user_id":"under","userId":"camel"}`+"`"+`
+	if err := json.Unmarshal([]byte(payload), &thing); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if thing.UserID != "dash" || thing.UserID2 != "under" || thing.UserID3 != "camel" {
+		t.Fatalf("decoded %+v, want each property in its own field", thing)
+	}
+
+	out, err := json.Marshal(thing)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back map[string]string
+	if err := json.Unmarshal(out, &back); err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	for key, want := range map[string]string{"user-id": "dash", "user_id": "under", "userId": "camel"} {
+		if back[key] != want {
+			t.Errorf("%s = %q, want %q", key, back[key], want)
+		}
+	}
+}
+`)
+}


### PR DESCRIPTION
Closes #96.

```yaml
Thing:
  type: object
  properties:
    user-id: { type: string }
    user_id: { type: string }
    userId:  { type: string }
```

```
./types.go:7:2: UserID redeclared
	./types.go:6:2: other declaration of UserID
./types.go:8:2: UserID redeclared
```

The package did not build, so nothing in the spec was reachable, not just the type that collided. Mixed conventions inside one schema are ordinary in specs that grew over time.

## Fix

```go
type Thing struct {
	UserID  *string `json:"user-id,omitempty"`
	UserID2 *string `json:"user_id,omitempty"`
	UserID3 *string `json:"userId,omitempty"`
}
```

Fields join a struct through one place that numbers a name the struct already declares. Only the Go name moves; each field keeps its own JSON tag, so the wire is unchanged and a payload using all three still round-trips with them kept apart.

Applied where a field joins a struct rather than only on the property path, so it also covers:

- properties merged from several `allOf` entries,
- an embedded type from `allOf` colliding with a property beside it (`allOf: [Base, {properties: {base: ...}}]` gives `Base` and `Base2`),
- the synthetic `additionalProperties` catch-all, which had its own copy of this logic and now shares the general one.

## Tests

- `internal/analyzer/schemas_field_collision_test.go`: three colliding properties are numbered in declaration order with their tags intact, an embedded type and a property that collide are kept apart, and a declared `additionalProperties` property pushes the catch-all to `AdditionalProperties2`.
- `internal/generator/e2e_field_collision_test.go`: compiles and runs, decoding a payload that uses all three spellings and marshaling it back with each property under its own key.

`gofmt`, `go vet ./...`, and `go test ./...` pass.