### PR TITLE
fix(generator): operations, header fields, and webhooks redeclared derived names

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -30,6 +30,10 @@ type Analyzer struct {
 	// before any conversion so a reference to a schema that has not been converted
 	// yet still resolves to the name it will end up with.
 	goNameBySchema map[string]string
+	// opNames fixes each operation's Go name the first time it is asked for, and
+	// opNamesTaken keeps two operations from landing on one method.
+	opNames      map[string]string
+	opNamesTaken map[string]bool
 	// multiContentResponses counts responses offering more than one media type,
 	// of which the generated method decodes one.
 	multiContentResponses int
@@ -53,6 +57,8 @@ func New(model *v3high.Document) *Analyzer {
 		synthesizedByKey:      make(map[string]*ir.TypeDef),
 		inlineMultipartBodies: make(map[string]bool),
 		goNameBySchema:        make(map[string]string),
+		opNames:               make(map[string]string),
+		opNamesTaken:          make(map[string]bool),
 	}
 }
 

--- a/internal/analyzer/operations.go
+++ b/internal/analyzer/operations.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -335,12 +336,30 @@ func disambiguateParamNames(opDef *ir.OperationDef) {
 
 // operationName determines the Go method name for an operation.
 func (a *Analyzer) operationName(httpMethod, path string, op *v3high.Operation) string {
-	if op.OperationId != "" {
-		return naming.Exported(op.OperationId)
+	// Several passes ask for the same operation's name, and every identifier
+	// built from it has to agree with the method, so the answer is decided once.
+	key := httpMethod + " " + path
+	if name, ok := a.opNames[key]; ok {
+		return name
 	}
-	// Generate from HTTP method + path.
-	// e.g., GET /users/{id} → GetUsersByID
-	return naming.Exported(strings.ToLower(httpMethod) + " " + pathToWords(path))
+
+	base := naming.Exported(op.OperationId)
+	if op.OperationId == "" {
+		// Generate from HTTP method + path.
+		// e.g., GET /users/{id} → GetUsersByID
+		base = naming.Exported(strings.ToLower(httpMethod) + " " + pathToWords(path))
+	}
+
+	// Methods live in Client's method set rather than the package scope, so they
+	// are numbered against each other and not against a schema that happens to
+	// share the name.
+	name := base
+	for i := 2; a.opNamesTaken[name]; i++ {
+		name = base + strconv.Itoa(i)
+	}
+	a.opNamesTaken[name] = true
+	a.opNames[key] = name
+	return name
 }
 
 // pathToWords converts a URL path to space-separated words for naming.

--- a/internal/analyzer/operations_test.go
+++ b/internal/analyzer/operations_test.go
@@ -788,3 +788,64 @@ func TestInlineMultipart_BinaryPropertyBecomesAFilePart(t *testing.T) {
 		t.Errorf("json blob = %q, want []byte", jsonBody.Fields[0].Type)
 	}
 }
+
+const collidingOperationSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a-b:
+    get:
+      responses: { "204": { description: ok } }
+  /a_b:
+    get:
+      responses: { "204": { description: ok } }
+  /dup:
+    get:
+      operationId: sameName
+      parameters:
+        - { name: q, in: query, schema: { type: string } }
+      responses: { "204": { description: ok } }
+  /dup2:
+    get:
+      operationId: same-name
+      parameters:
+        - { name: q, in: query, schema: { type: string } }
+      responses: { "204": { description: ok } }
+`
+
+// Two operations can derive one method name, from paths that differ only in
+// punctuation or from operation ids that normalize together.
+func TestOperationNames_CollisionsAreNumbered(t *testing.T) {
+	pkg, typeMap := analyzeSpec(t, collidingOperationSpec)
+
+	var names []string
+	for _, op := range pkg.Operations {
+		names = append(names, op.Name)
+	}
+	want := []string{"GetAB", "GetAB2", "SameName", "SameName2"}
+	if len(names) != len(want) {
+		t.Fatalf("operations = %v, want %v", names, want)
+	}
+	for i, w := range want {
+		if names[i] != w {
+			t.Errorf("operation %d = %q, want %q", i, names[i], w)
+		}
+	}
+
+	// The names params types are built from have to follow the method, or the
+	// two would disagree about which operation they belong to.
+	for _, name := range []string{"SameName", "SameName2"} {
+		var op *ir.OperationDef
+		for _, candidate := range pkg.Operations {
+			if candidate.Name == name {
+				op = candidate
+			}
+		}
+		if op == nil {
+			t.Fatalf("%s not found", name)
+		}
+		if len(op.QueryParams) != 1 {
+			t.Errorf("%s params = %+v", name, op.QueryParams)
+		}
+	}
+	_ = typeMap
+}

--- a/internal/analyzer/webhooks.go
+++ b/internal/analyzer/webhooks.go
@@ -68,6 +68,10 @@ func (a *Analyzer) inboundPayloads(name, goName string, callback bool, pathItem 
 			methodKey += "." + m.method
 		}
 
+		// Two spec keys can normalize to one Go name, and the parse functions
+		// built from it share the package scope.
+		methodName = a.namer.Unique(methodName)
+
 		payloadType, ok := a.inboundPayloadType(m.op, methodName)
 		if !ok {
 			warnings = append(warnings, fmt.Sprintf("%s %q: no JSON request body to decode, so no parse function is generated", inboundKind(callback), methodKey))

--- a/internal/generator/e2e_name_collision_derived_test.go
+++ b/internal/generator/e2e_name_collision_derived_test.go
@@ -1,0 +1,135 @@
+package generator
+
+import "testing"
+
+const derivedNameCollisionSpec = `openapi: 3.1.0
+info: { title: coll, version: "1" }
+webhooks:
+  pet-created:
+    post:
+      requestBody:
+        content:
+          application/json: { schema: { $ref: "#/components/schemas/Pet" } }
+  pet_created:
+    post:
+      requestBody:
+        content:
+          application/json: { schema: { $ref: "#/components/schemas/Pet" } }
+paths:
+  /a-b:
+    get:
+      responses: { "204": { description: ok } }
+  /a_b:
+    get:
+      responses: { "204": { description: ok } }
+  /dup:
+    get:
+      operationId: sameName
+      responses: { "204": { description: ok } }
+  /dup2:
+    get:
+      operationId: same-name
+      responses: { "204": { description: ok } }
+  /hdr:
+    get:
+      operationId: getHdr
+      responses:
+        "200":
+          description: ok
+          headers:
+            x-trace: { schema: { type: string } }
+            X_Trace: { schema: { type: string } }
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Pet" } }
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name: { type: string }
+`
+
+// TestE2E_DerivedNameCollisions covers the identifiers built from spec names
+// rather than from schemas: methods, response header fields, and webhook parse
+// functions. Each collided into a redeclaration that broke the whole package.
+func TestE2E_DerivedNameCollisions(t *testing.T) {
+	files, _ := generateFromSpec(t, derivedNameCollisionSpec, "collapi")
+
+	runGeneratedWireTest(t, files, "derivedcollision", `package collapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Both paths and both operation ids keep a method of their own, and each still
+// requests the path it came from.
+func TestCollidingOperationsKeepTheirPaths(t *testing.T) {
+	var asked []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = append(asked, r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.GetAB(t.Context()); err != nil {
+		t.Fatalf("GetAB: %v", err)
+	}
+	if err := c.GetAB2(t.Context()); err != nil {
+		t.Fatalf("GetAB2: %v", err)
+	}
+	if err := c.SameName(t.Context()); err != nil {
+		t.Fatalf("SameName: %v", err)
+	}
+	if err := c.SameName2(t.Context()); err != nil {
+		t.Fatalf("SameName2: %v", err)
+	}
+
+	want := []string{"/a-b", "/a_b", "/dup", "/dup2"}
+	for i, w := range want {
+		if asked[i] != w {
+			t.Errorf("call %d requested %q, want %q", i, asked[i], w)
+		}
+	}
+}
+
+// Header names are distinct spec keys even when they normalize to one field.
+func TestCollidingHeadersAreReadable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-trace", "first")
+		w.Header().Set("X_Trace", "second")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"name": "Rex"})
+	}))
+	defer srv.Close()
+
+	ctx, meta := WithResponseCapture(t.Context())
+	if _, err := NewClient(srv.URL).GetHdr(ctx); err != nil {
+		t.Fatalf("GetHdr: %v", err)
+	}
+	h := meta.GetHdrHeaders()
+	if h.XTrace != "first" || h.XTrace2 != "second" {
+		t.Errorf("headers = %+v, want each spec key in its own field", h)
+	}
+}
+
+// Each webhook keeps a parse function of its own, and the dispatcher still
+// routes both names.
+func TestCollidingWebhooksBothParse(t *testing.T) {
+	if _, err := ParsePetCreatedWebhook([]byte(`+"`"+`{"name":"a"}`+"`"+`)); err != nil {
+		t.Fatalf("ParsePetCreatedWebhook: %v", err)
+	}
+	if _, err := ParsePetCreated2Webhook([]byte(`+"`"+`{"name":"b"}`+"`"+`)); err != nil {
+		t.Fatalf("ParsePetCreated2Webhook: %v", err)
+	}
+	for _, name := range []string{"pet-created", "pet_created"} {
+		if _, err := ParseWebhook(name, []byte(`+"`"+`{"name":"c"}`+"`"+`)); err != nil {
+			t.Errorf("ParseWebhook(%q): %v", name, err)
+		}
+	}
+}
+`)
+}

--- a/internal/generator/funcmap.go
+++ b/internal/generator/funcmap.go
@@ -693,6 +693,7 @@ func reservedQueryParams(op *ir.OperationDef) []*ir.ParamDef {
 func operationHeaders(op *ir.OperationDef) []*ir.ResponseHeaderDef {
 	var headers []*ir.ResponseHeaderDef
 	seen := map[string]bool{}
+	taken := map[string]bool{}
 	for _, resp := range op.Responses {
 		for _, h := range resp.Headers {
 			key := strings.ToLower(h.Name)
@@ -700,7 +701,16 @@ func operationHeaders(op *ir.OperationDef) []*ir.ResponseHeaderDef {
 				continue
 			}
 			seen[key] = true
-			headers = append(headers, h)
+
+			// Two header names that differ as spec keys can normalize to one Go
+			// field, which the struct they share would redeclare.
+			field := *h
+			base := field.GoName
+			for i := 2; taken[field.GoName]; i++ {
+				field.GoName = base + strconv.Itoa(i)
+			}
+			taken[field.GoName] = true
+			headers = append(headers, &field)
 		}
 	}
 	return headers


### PR DESCRIPTION
Closes #98. Same defect class as #96, everywhere else it appears.

Each of these breaks the build of the entire generated package, not just the piece that collided.

## Operation methods

```yaml
/a-b: { get: ... }
/a_b: { get: ... }
/dup:  { get: { operationId: sameName } }
/dup2: { get: { operationId: same-name } }
```

```
./operations.go:17:18: method Client.GetAB already declared at ./operations.go:9:18
./operations.go:33:18: method Client.SameName already declared at ./operations.go:25:18
```

An operation's name is now decided once and remembered, then numbered against the other methods: `GetAB`/`GetAB2`, `SameName`/`SameName2`.

Deciding once matters beyond the collision: several passes ask for the same operation's name, and every identifier built from it (`<Op>Params`, `<Op>Headers`, `<Op>Body`, `<Op>Iter`, `Parse<Op><Callback>Callback`) has to agree with the method. Recomputing per pass would have handed different passes different answers.

**Numbered against other methods, not against the package scope.** A method lives in `Client`'s method set, so a schema named `GetAB` is not a conflict, and moving the method aside for it would be a rename nobody asked for.

## Response header fields

```yaml
headers:
  x-trace: { schema: { type: string } }
  X_Trace: { schema: { type: string } }
```

```
./responses.go:50:2: XTrace redeclared
./responses.go:58:3: duplicate field name XTrace in struct literal
```

Numbered within the operation that declares them, after the merge across that operation's responses, since that is the struct they share. Each field keeps reading its own header.

## Webhook parse functions

```yaml
webhooks:
  pet-created: { post: ... }
  pet_created: { post: ... }
```

```
./webhooks.go:29:6: ParsePetCreatedWebhook redeclared in this block
```

These are package-scope identifiers, so they go through the naming scope with everything else there.

## Tests

- `internal/analyzer/operations_test.go`: colliding paths and colliding operation ids are numbered in spec order, and each operation keeps its own parameters.
- `internal/generator/e2e_name_collision_derived_test.go`: compiles and runs, checking each of the four methods requests the path it came from, both header fields read their own spec key through `ResponseMeta`, and both webhooks parse and still dispatch by name.

`gofmt`, `go vet ./...`, and `go test ./...` pass.