### PR TITLE
fix(generator): an optional body left out was sent as the JSON literal null

### DIFF
--- a/internal/generator/e2e_optional_body_test.go
+++ b/internal/generator/e2e_optional_body_test.go
@@ -1,0 +1,104 @@
+package generator
+
+import "testing"
+
+const optionalBodySpec = `openapi: 3.1.0
+info: { title: opt, version: "1" }
+paths:
+  /things:
+    post:
+      operationId: createThing
+      requestBody:
+        required: false
+        content:
+          application/json: { schema: { $ref: "#/components/schemas/Thing" } }
+      responses: { "204": { description: ok } }
+  /required:
+    post:
+      operationId: createRequired
+      requestBody:
+        required: true
+        content:
+          application/json: { schema: { $ref: "#/components/schemas/Thing" } }
+      responses: { "204": { description: ok } }
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        name: { type: string }
+`
+
+// TestE2E_OptionalBodyOmitted covers an optional body left out. It reached the
+// encoder as a nil pointer inside an interface, which is not nil, so the request
+// carried the JSON literal null and a Content-Type to go with it.
+func TestE2E_OptionalBodyOmitted(t *testing.T) {
+	files, _ := generateFromSpec(t, optionalBodySpec, "optapi")
+
+	runGeneratedWireTest(t, files, "optionalbody", `package optapi
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func sent(t *testing.T) (*Client, *string, *string, *int64) {
+	t.Helper()
+	var payload, ctype string
+	var length int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		payload, ctype, length = string(b), r.Header.Get("Content-Type"), r.ContentLength
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL), &payload, &ctype, &length
+}
+
+func TestNilOptionalBodySendsNothing(t *testing.T) {
+	client, payload, ctype, length := sent(t)
+
+	if err := client.CreateThing(t.Context(), nil); err != nil {
+		t.Fatalf("CreateThing: %v", err)
+	}
+	if *payload != "" {
+		t.Errorf("payload = %q, want no body at all", *payload)
+	}
+	if *ctype != "" {
+		t.Errorf("Content-Type = %q, want none for a request with no body", *ctype)
+	}
+	if *length > 0 {
+		t.Errorf("Content-Length = %d, want no body", *length)
+	}
+}
+
+// A body that is present still goes, including one whose fields are all unset.
+func TestPresentOptionalBodyIsSent(t *testing.T) {
+	client, payload, ctype, _ := sent(t)
+
+	if err := client.CreateThing(t.Context(), &Thing{}); err != nil {
+		t.Fatalf("CreateThing: %v", err)
+	}
+	if *payload != "{}" {
+		t.Errorf("payload = %q, want the empty object the caller passed", *payload)
+	}
+	if *ctype != "application/json" {
+		t.Errorf("Content-Type = %q", *ctype)
+	}
+}
+
+func TestRequiredBodyIsUnaffected(t *testing.T) {
+	client, payload, _, _ := sent(t)
+
+	name := "a"
+	if err := client.CreateRequired(t.Context(), Thing{Name: &name}); err != nil {
+		t.Fatalf("CreateRequired: %v", err)
+	}
+	if *payload != `+"`"+`{"name":"a"}`+"`"+` {
+		t.Errorf("payload = %q", *payload)
+	}
+}
+`)
+}

--- a/internal/templates/client.go.tmpl
+++ b/internal/templates/client.go.tmpl
@@ -67,7 +67,7 @@ func (c *Client) do(ctx context.Context, method string, path string, body any, c
 	fullURL := c.baseURL + path
 
 	var payload []byte
-	if body != nil {
+	if hasRequestBody(body) {
 		var err error
 		payload, contentType, err = encodeRequestBody(body, contentType)
 		if err != nil {

--- a/internal/templates/helpers.go.tmpl
+++ b/internal/templates/helpers.go.tmpl
@@ -427,6 +427,18 @@ func pathSep(explode bool, exploded string) string {
 	return ","
 }
 
+// hasRequestBody reports whether there is a body to send. An optional body
+// arrives as a nil pointer inside an interface, which is not itself nil, and
+// encoding it would send the JSON literal null where the caller meant to send
+// nothing at all.
+func hasRequestBody(body any) bool {
+	if body == nil {
+		return false
+	}
+	rv := reflect.ValueOf(body)
+	return rv.Kind() != reflect.Pointer || !rv.IsNil()
+}
+
 // isRawResult fills a result the operation types as bytes or text with the body
 // as it arrived, reporting whether it did. Such a body is the value itself, not
 // a document to parse.


### PR DESCRIPTION
Closes #102.

```go
client.CreateThing(ctx, nil)   // requestBody: required: false
```

```
payload="null" content-type="application/json"
```

The request carried a body and a Content-Type where the caller meant to send neither. "No body" and "a body that is null" are different things to a server: many reject `null` where an object is expected, and one that accepts it may read it as an instruction to clear a resource.

## Cause

`do` takes the body as `any` and checks it against nil. The caller passes a `*Thing` that is nil, and an interface holding a typed nil pointer is not nil, so the encode ran and `json.Marshal` produced `null`.

```go
if hasRequestBody(body) {   // was: if body != nil
```

**Only pointers count as absent.** A nil slice or map reaches `do` as the value a caller supplied for a required body, where `null` renders what they passed, and a pointer is how the generator expresses optionality in the first place.

## Tests

`internal/generator/e2e_optional_body_test.go` compiles and runs against `httptest`: a nil optional body sends no payload, no Content-Type, and no Content-Length; a present but empty body still sends `{}` with its Content-Type, so "omitted" and "empty" stay distinguishable; and a required body is unaffected.

`gofmt`, `go vet ./...`, and `go test ./...` pass.