### PR TITLE
fix(parser): a relative $ref resolved against the working directory

### DIFF
--- a/internal/analyzer/schemas.go
+++ b/internal/analyzer/schemas.go
@@ -741,8 +741,14 @@ func (a *Analyzer) synthesizeInlineObject(schema *highbase.Schema, nameHint stri
 
 	// A titled schema names itself, which keeps the generated name stable when
 	// the property that reaches it first is renamed.
-	if schema.Title != "" {
+	switch {
+	case schema.Title != "":
 		nameHint = schema.Title
+	case externalRefName(schema) != "":
+		// A schema in another file is shared by everything that references it,
+		// so it is named for itself rather than for whichever property in this
+		// document happened to reach it first.
+		nameHint = externalRefName(schema)
 	}
 	if nameHint == "" {
 		return "", false
@@ -1014,6 +1020,22 @@ func refToSchemaName(ref string) string {
 	const prefix = "#/components/schemas/"
 	if len(ref) > len(prefix) && ref[:len(prefix)] == prefix {
 		return ref[len(prefix):]
+	}
+	return ""
+}
+
+// externalRefName returns the name a reference into another document ends with,
+// or "" for a local reference or none at all.
+func externalRefName(schema *highbase.Schema) string {
+	if schema.ParentProxy == nil {
+		return ""
+	}
+	ref := schema.ParentProxy.GetReference()
+	if ref == "" || strings.HasPrefix(ref, "#/") {
+		return ""
+	}
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		return ref[i+1:]
 	}
 	return ""
 }

--- a/internal/generator/e2e_multifile_test.go
+++ b/internal/generator/e2e_multifile_test.go
@@ -1,0 +1,119 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/parallelworks/openapi-client-generator/internal/analyzer"
+	"github.com/parallelworks/openapi-client-generator/internal/parser"
+)
+
+// TestE2E_MultiFileSpec covers a spec split across files, which is how large
+// specs are written. Relative references resolved against the working directory,
+// so generation failed outright unless it ran from the spec's own directory.
+func TestE2E_MultiFileSpec(t *testing.T) {
+	specDir := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(specDir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	write("common.yaml", `components:
+  schemas:
+    Shared:
+      type: object
+      properties:
+        id: { type: string }
+        label: { type: string }
+      required: [id]
+`)
+	write("api.yaml", `openapi: 3.1.0
+info: { title: multi, version: "1" }
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "./common.yaml#/components/schemas/Shared" }
+components:
+  schemas:
+    Wrapper:
+      type: object
+      properties:
+        primary: { $ref: "./common.yaml#/components/schemas/Shared" }
+        secondary: { $ref: "./common.yaml#/components/schemas/Shared" }
+`)
+
+	result, err := parser.Parse(filepath.Join(specDir, "api.yaml"), parser.Config{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	pkg, err := analyzer.New(result.Model).Analyze("multiapi")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	gen, err := New(pkg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	runGeneratedWireTest(t, files, "multifile", `package multiapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A schema in another file is named for itself, not for whichever property in
+// this document reached it first, and every reference to it shares that type.
+func TestExternalSchemaIsOneNamedType(t *testing.T) {
+	var w Wrapper
+	if err := json.Unmarshal([]byte(`+"`"+`{"primary":{"id":"a"},"secondary":{"id":"b","label":"l"}}`+"`"+`), &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.Primary == nil || w.Primary.ID != "a" {
+		t.Errorf("primary = %+v", w.Primary)
+	}
+	if w.Secondary == nil || w.Secondary.Label == nil || *w.Secondary.Label != "l" {
+		t.Errorf("secondary = %+v", w.Secondary)
+	}
+
+	// Both properties hold the same type, so a value moves between them.
+	w.Primary = w.Secondary
+	if w.Primary.ID != "b" {
+		t.Errorf("primary = %+v", w.Primary)
+	}
+}
+
+func TestOperationDecodesTheExternalSchema(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`+"`"+`[{"id":"x","label":"y"}]`+"`"+`))
+	}))
+	defer srv.Close()
+
+	things, err := NewClient(srv.URL).ListThings(t.Context())
+	if err != nil {
+		t.Fatalf("ListThings: %v", err)
+	}
+	if things == nil || len(*things) != 1 || (*things)[0].ID != "x" {
+		t.Errorf("things = %+v", things)
+	}
+}
+`)
+}

--- a/internal/parser/multifile_test.go
+++ b/internal/parser/multifile_test.go
@@ -1,0 +1,108 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A $ref is relative to the document holding it. Resolving it against the
+// working directory instead means a multi-file spec builds only when the
+// generator happens to run from the spec's own directory.
+func TestParse_RelativeFileRefsResolveAgainstTheSpec(t *testing.T) {
+	dir := t.TempDir()
+	writeSpecFile(t, dir, "common.yaml", `components:
+  schemas:
+    Shared:
+      type: object
+      properties:
+        id: { type: string }
+      required: [id]
+`)
+	writeSpecFile(t, dir, "api.yaml", `openapi: 3.1.0
+info: { title: multi, version: "1" }
+paths: {}
+components:
+  schemas:
+    Local:
+      type: object
+      properties:
+        shared: { $ref: "./common.yaml#/components/schemas/Shared" }
+`)
+
+	// Deliberately not the spec's directory: this is the CI case.
+	chdir(t, t.TempDir())
+
+	result, err := Parse(filepath.Join(dir, "api.yaml"), Config{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	schemas := result.Model.Components.Schemas
+	local, ok := schemas.Get("Local")
+	if !ok {
+		t.Fatal("Local not found")
+	}
+	built, err := local.Schema().Properties.GetOrZero("shared").BuildSchema()
+	if err != nil {
+		t.Fatalf("building the referenced schema: %v", err)
+	}
+	if built == nil || built.Properties == nil || built.Properties.Len() != 1 {
+		t.Fatalf("the reference into common.yaml did not resolve: %+v", built)
+	}
+	if _, ok := built.Properties.Get("id"); !ok {
+		t.Error("the resolved schema is missing the property it declares")
+	}
+}
+
+// A spec may reference a file outside its own directory, so the base path is a
+// starting point rather than a boundary.
+func TestParse_RefsAboveTheSpecDirectoryStillResolve(t *testing.T) {
+	root := t.TempDir()
+	writeSpecFile(t, root, "common.yaml", `components:
+  schemas:
+    Shared:
+      type: object
+      properties:
+        id: { type: string }
+`)
+	specDir := filepath.Join(root, "api")
+	if err := os.Mkdir(specDir, 0o755); err != nil {
+		t.Fatalf("creating the spec directory: %v", err)
+	}
+	writeSpecFile(t, specDir, "api.yaml", `openapi: 3.1.0
+info: { title: multi, version: "1" }
+paths: {}
+components:
+  schemas:
+    Local:
+      type: object
+      properties:
+        shared: { $ref: "../common.yaml#/components/schemas/Shared" }
+`)
+
+	chdir(t, t.TempDir())
+
+	if _, err := Parse(filepath.Join(specDir, "api.yaml"), Config{}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+}
+
+func writeSpecFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(previous) })
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
@@ -28,7 +29,15 @@ func Parse(specPath string, cfg Config) (*ParseResult, error) {
 		return nil, fmt.Errorf("reading spec file: %w", err)
 	}
 
+	// A $ref is relative to the document holding it, not to wherever the
+	// generator was run from, so file references start at the spec's directory.
+	basePath, err := filepath.Abs(filepath.Dir(specPath))
+	if err != nil {
+		return nil, fmt.Errorf("resolving the spec's directory: %w", err)
+	}
+
 	docConfig := &datamodel.DocumentConfiguration{
+		BasePath:              basePath,
 		AllowFileReferences:   true,
 		AllowRemoteReferences: cfg.AllowRemoteRefs,
 	}


### PR DESCRIPTION
Closes #104.

```
$ go run . generate --spec /path/to/spec/api.yaml --out ./out
ERROR unable to open the rolodex file, check specification references and base path
      file=/current/working/directory/common.yaml
warning: component `#/components/schemas/Shared` does not exist in the specification
exit status 1
```

It looked for `common.yaml` beside the process rather than beside the spec that references it. File references were enabled without a `BasePath`, so libopenapi resolved them against the working directory.

Multi-file specs are how large specs are written, and this fails outright rather than degrading: nothing is generated. It is also easy to miss, since running from the spec's directory works, so it surfaces first in a CI step that runs from a repo root.

References now start at the spec's directory. A reference above it (`../common.yaml`) keeps working, since a base path is a starting point rather than a boundary.

## Naming, which the fix would otherwise leave half done

A schema in another file is not a component of the document being generated, so it was synthesized under the name of whatever property reached it first:

```go
type Local struct {
	Shared *LocalShared `json:"shared,omitempty"`   // before
}
```

A second property referencing the same external schema would take its name from that property instead, and only shape deduplication kept them from becoming two types. An external schema is shared by everything that references it, so it is now named for itself:

```go
type Local struct {
	Shared *Shared `json:"shared,omitempty"`
}
```

A `title` still wins, as it does for any inline schema.

## Tests

- `internal/parser/multifile_test.go`: a relative reference resolves while the process runs somewhere else entirely, which is the CI case, and a reference above the spec's directory resolves too.
- `internal/generator/e2e_multifile_test.go`: generates from a two-file spec, then compiles and runs the client, checking two properties referencing one external schema share a single named type (a value moves between them) and that an operation returning an array of it decodes.

`gofmt`, `go vet ./...`, and `go test ./...` pass.