### PR TITLE
fix(pagination): a page size named perPage was not recognized

### DIFF
--- a/internal/analyzer/pagination.go
+++ b/internal/analyzer/pagination.go
@@ -110,7 +110,9 @@ func (a *Analyzer) detectOffsetPagination(op *ir.OperationDef, pkg *ir.Package) 
 		return nil
 	}
 
-	for _, name := range []string{"per_page", "page_size", "pagesize", "limit"} {
+	// Both spellings of each name: the comparison is case-insensitive, so
+	// perpage covers perPage and pagesize covers pageSize.
+	for _, name := range []string{"per_page", "perpage", "page_size", "pagesize", "limit"} {
 		if orig, ok := queryNames[name]; ok {
 			return a.buildOffsetPagination(op, pkg, ir.PaginationStylePage, pageParam, orig)
 		}

--- a/internal/analyzer/pagination_test.go
+++ b/internal/analyzer/pagination_test.go
@@ -290,3 +290,72 @@ func TestPaginationItems_NoArrayGetsNoIterator(t *testing.T) {
 		t.Errorf("pagination = %+v, want none: the response holds no page", pd)
 	}
 }
+
+const camelPageSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - { name: page, in: query, schema: { type: integer } }
+        - { name: perPage, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+  /others:
+    get:
+      operationId: listOthers
+      parameters:
+        - { name: page, in: query, schema: { type: integer } }
+        - { name: pageSize, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+components:
+  schemas:
+    Page:
+      type: object
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/Item" } }
+    Item:
+      type: object
+      properties: { id: { type: string } }
+`
+
+// Both spellings of a page size are recognized. perPage was not, so a spec
+// written in camelCase, which is what several generators emit, paginated
+// nowhere: the Mealie spec in #15 declares page and perPage on 30 endpoints.
+func TestPagination_CamelCasePageSize(t *testing.T) {
+	pkg, _ := analyzeSpec(t, camelPageSpec)
+
+	for _, op := range pkg.Operations {
+		if op.Pagination == nil {
+			t.Errorf("%s has no pagination, want the page style", op.Name)
+			continue
+		}
+		if op.Pagination.Style != ir.PaginationStylePage {
+			t.Errorf("%s style = %v, want PaginationStylePage", op.Name, op.Pagination.Style)
+		}
+		if op.Pagination.OffsetParam != "page" {
+			t.Errorf("%s advances %q, want page", op.Name, op.Pagination.OffsetParam)
+		}
+	}
+
+	byName := map[string]string{}
+	for _, op := range pkg.Operations {
+		if op.Pagination != nil {
+			byName[op.Name] = op.Pagination.LimitParam
+		}
+	}
+	if byName["ListItems"] != "perPage" {
+		t.Errorf("ListItems limit param = %q, want perPage", byName["ListItems"])
+	}
+	if byName["ListOthers"] != "pageSize" {
+		t.Errorf("ListOthers limit param = %q, want pageSize", byName["ListOthers"])
+	}
+}


### PR DESCRIPTION
Closes #108. Found by generating against the Mealie spec attached to #15, rather than against a spec I wrote.

```go
for _, name := range []string{"per_page", "page_size", "pagesize", "limit"} {
```

The comparison is case-insensitive but not spelling-insensitive. `page_size` and `pagesize` are both listed, so `pageSize` matches. `per_page` stands alone, so `perPage` matches nothing.

Mealie declares `page` and `perPage` on **30 endpoints**, and generated **zero** iterators. With `perpage` added, all 30 get one, typed to the element the endpoint returns:

```go
func (c *Client) GetAllAPIHouseholdsCookbooksGetIter(ctx context.Context, opts ...GetAllAPIHouseholdsCookbooksGetParams) *PageIterator[ReadCookBook]
```

Every other list in the file already carries both spellings, so this closes a gap in one list rather than adopting a new convention:

```go
cursorParamNames = []string{"cursor", "after", "page_token", "pageToken", "next_token", "nextToken"}
```

Detection is otherwise unchanged: a `page` parameter still has to sit beside it, and the items field still has to identify itself under the rules from #65.

## Tests

`internal/analyzer/pagination_test.go`: a spec using `page` and `perPage` and one using `page` and `pageSize` both detect the page style, advance the `page` parameter, and record their own size parameter.

Also verified end to end on the Mealie spec: 250 types, 168 paths, 30 iterators, and the generated package compiles.

`gofmt`, `golangci-lint`, `go vet ./...`, and `go test ./...` pass.