### PR TITLE
fix(pagination): skip was not recognized as an offset

### DIFF
--- a/internal/analyzer/pagination.go
+++ b/internal/analyzer/pagination.go
@@ -90,9 +90,14 @@ func (a *Analyzer) detectOffsetPagination(op *ir.OperationDef, pkg *ir.Package) 
 	offsetParam := ""
 	limitParam := ""
 
-	// Check for offset + limit pattern.
-	if orig, ok := queryNames["offset"]; ok {
-		offsetParam = orig
+	// Check for offset + limit pattern. skip is the other spelling of an offset:
+	// OData writes $skip, and APIs built on Mongo or on Go frameworks use it as
+	// often as offset.
+	for _, name := range []string{"offset", "skip"} {
+		if orig, ok := queryNames[name]; ok {
+			offsetParam = orig
+			break
+		}
 	}
 	if orig, ok := queryNames["limit"]; ok {
 		limitParam = orig

--- a/internal/analyzer/pagination_test.go
+++ b/internal/analyzer/pagination_test.go
@@ -359,3 +359,87 @@ func TestPagination_CamelCasePageSize(t *testing.T) {
 		t.Errorf("ListOthers limit param = %q, want pageSize", byName["ListOthers"])
 	}
 }
+
+const skipOffsetSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /runs:
+    get:
+      operationId: listRuns
+      parameters:
+        - { name: skip, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/RunList" } }
+  /both:
+    get:
+      operationId: listBoth
+      parameters:
+        - { name: offset, in: query, schema: { type: integer } }
+        - { name: skip, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/RunList" } }
+  /alone:
+    get:
+      operationId: listAlone
+      parameters:
+        - { name: skip, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/RunList" } }
+components:
+  schemas:
+    RunList:
+      type: object
+      properties:
+        runs: { type: array, items: { $ref: "#/components/schemas/Run" } }
+        total: { type: integer }
+    Run:
+      type: object
+      properties: { id: { type: string } }
+`
+
+// skip is the other spelling of an offset, and the convention 15 endpoints of
+// one real spec use. It advances by items received, exactly as offset does.
+func TestPagination_SkipIsAnOffset(t *testing.T) {
+	pkg, _ := analyzeSpec(t, skipOffsetSpec)
+
+	byName := map[string]*ir.PaginationDef{}
+	for _, op := range pkg.Operations {
+		byName[op.Name] = op.Pagination
+	}
+
+	runs := byName["ListRuns"]
+	if runs == nil {
+		t.Fatal("ListRuns has no pagination")
+	}
+	if runs.Style != ir.PaginationStyleOffset {
+		t.Errorf("ListRuns style = %v, want PaginationStyleOffset", runs.Style)
+	}
+	if runs.OffsetParam != "skip" || runs.LimitParam != "limit" {
+		t.Errorf("ListRuns advances %q by %q, want skip and limit", runs.OffsetParam, runs.LimitParam)
+	}
+	if runs.ItemsField != "runs" {
+		t.Errorf("ListRuns items = %q, want runs", runs.ItemsField)
+	}
+
+	// A spec offering both names is answered with offset, the one the standard
+	// spells out.
+	if both := byName["ListBoth"]; both == nil || both.OffsetParam != "offset" {
+		t.Errorf("ListBoth advances %+v, want offset", both)
+	}
+
+	// An advancing parameter with nothing to size a page is not pagination.
+	if alone := byName["ListAlone"]; alone != nil {
+		t.Errorf("ListAlone pagination = %+v, want none", alone)
+	}
+}


### PR DESCRIPTION
Closes #110. Found by generating against the ACTIVATE spec.

```go
if orig, ok := queryNames["offset"]; ok {
```

`skip` means the same thing: OData spells it `$skip`, and APIs built on Mongo or on Go frameworks pair it with `limit` exactly as `offset` does.

## Measured on a 577-path spec

| parameters | operations | iterator before |
|---|---|---|
| `limit` + `skip` | 15 | no |
| `limit` + `offset` | 7 | yes |
| `cursor` + `limit` | 3 | yes |
| `page` + `per_page` | 1 | yes |
| `page` + `pageSize` | 1 | yes |

The convention the generator did not know was the largest one in the spec, bigger than the other three combined. Iterators generated for it go from 12 to 17, and the generated package still compiles.

Five rather than fifteen because the rest return a bare array instead of a page object, which the detector cannot express yet. That is #112, and it is worth most of the remainder on this spec alone.

## Decisions

- **`offset` wins when a spec offers both**, since it is the name the OpenAPI ecosystem spells out.
- **Nothing else loosens.** `skip` advances by items received exactly as `offset` does, so it needs no new style, and detection still requires a `limit` beside it and an items field that identifies itself under #65's rules.

## Tests

`internal/analyzer/pagination_test.go`: `skip` and `limit` detect the offset style and record the right parameters and items field, a spec declaring both `offset` and `skip` chooses `offset`, and `skip` with nothing to size a page is not pagination.

`gofmt`, `golangci-lint`, `go vet ./...`, and `go test ./...` pass.
