### PR TITLE
feat(pagination): an endpoint returning the array itself gets an iterator

### DIFF
--- a/internal/analyzer/pagination.go
+++ b/internal/analyzer/pagination.go
@@ -130,11 +130,25 @@ func (a *Analyzer) detectOffsetPagination(op *ir.OperationDef, pkg *ir.Package) 
 // than follow a cursor. The style decides how the parameter advances: an offset
 // by the items received, a page by one.
 func (a *Analyzer) buildOffsetPagination(op *ir.OperationDef, pkg *ir.Package, style ir.PaginationStyle, offsetParam, limitParam string) *ir.PaginationDef {
+	byName := ir.TypesByName(pkg.Types)
+
+	// A response that is the array is the page: there is no field to find, and
+	// nothing to choose between.
+	if elem, ok := responseArrayElem(byName, op); ok {
+		return &ir.PaginationDef{
+			Style:            style,
+			OffsetParam:      offsetParam,
+			LimitParam:       limitParam,
+			ItemsType:        elem,
+			ItemsAreResponse: true,
+		}
+	}
+
 	respType := a.findSuccessResponseType(op, pkg)
 	if respType == nil {
 		return nil
 	}
-	items := findItemsField(ir.TypesByName(pkg.Types), respType)
+	items := findItemsField(byName, respType)
 	if items.name == "" {
 		return nil
 	}
@@ -193,6 +207,26 @@ func findItemsField(byName map[string]*ir.TypeDef, td *ir.TypeDef) itemsFieldInf
 		return itemsFieldInfo{name: records[0].JSONName, elemType: records[0].Type[2:]}
 	}
 	return itemsFieldInfo{}
+}
+
+// responseArrayElem returns the element type of a success response that is
+// itself an array, following the aliases a spec may name one under.
+func responseArrayElem(byName map[string]*ir.TypeDef, op *ir.OperationDef) (string, bool) {
+	if op.SuccessResponse == nil {
+		return "", false
+	}
+	goType := op.SuccessResponse.TypeName
+	for range len(byName) + 1 {
+		if elem, ok := strings.CutPrefix(goType, "[]"); ok {
+			return elem, elem != ""
+		}
+		td := byName[ir.NamedType(goType)]
+		if td == nil || td.Kind != ir.TypeKindAlias {
+			return "", false
+		}
+		goType = td.GoType
+	}
+	return "", false
 }
 
 // recordArrays returns the array fields whose element type is a type the spec

--- a/internal/analyzer/pagination_test.go
+++ b/internal/analyzer/pagination_test.go
@@ -443,3 +443,87 @@ func TestPagination_SkipIsAnOffset(t *testing.T) {
 		t.Errorf("ListAlone pagination = %+v, want none", alone)
 	}
 }
+
+const bareArrayPageSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /alerts:
+    get:
+      operationId: listAlerts
+      parameters:
+        - { name: skip, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: array, items: { $ref: "#/components/schemas/Alert" } }
+  /named:
+    get:
+      operationId: listNamed
+      parameters:
+        - { name: offset, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/AlertList" } }
+  /scalar:
+    get:
+      operationId: listScalar
+      parameters:
+        - { name: offset, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { type: string } }
+components:
+  schemas:
+    AlertList:
+      type: array
+      items: { $ref: "#/components/schemas/Alert" }
+    Alert:
+      type: object
+      properties: { id: { type: string } }
+`
+
+// A response that is the array is the page. There is no field to name and
+// nothing to choose between, which is why this needs no rule about which array
+// counts.
+func TestPagination_BareArrayResponseIsThePage(t *testing.T) {
+	pkg, _ := analyzeSpec(t, bareArrayPageSpec)
+
+	byName := map[string]*ir.PaginationDef{}
+	for _, op := range pkg.Operations {
+		byName[op.Name] = op.Pagination
+	}
+
+	alerts := byName["ListAlerts"]
+	if alerts == nil {
+		t.Fatal("ListAlerts has no pagination")
+	}
+	if !alerts.ItemsAreResponse {
+		t.Error("ListAlerts should page over the response itself")
+	}
+	if alerts.ItemsField != "" {
+		t.Errorf("ListAlerts items field = %q, want none", alerts.ItemsField)
+	}
+	if alerts.ItemsType != "Alert" {
+		t.Errorf("ListAlerts items type = %q, want Alert", alerts.ItemsType)
+	}
+
+	// A spec may name the array, which is the same page behind an alias.
+	named := byName["ListNamed"]
+	if named == nil || !named.ItemsAreResponse || named.ItemsType != "Alert" {
+		t.Errorf("ListNamed pagination = %+v, want the aliased array's element", named)
+	}
+
+	// A response that is neither a page object nor an array is not a page.
+	if scalar := byName["ListScalar"]; scalar != nil {
+		t.Errorf("ListScalar pagination = %+v, want none", scalar)
+	}
+}

--- a/internal/generator/e2e_bare_array_pagination_test.go
+++ b/internal/generator/e2e_bare_array_pagination_test.go
@@ -1,0 +1,90 @@
+package generator
+
+import "testing"
+
+const bareArrayPaginationSpec = `openapi: 3.1.0
+info: { title: alerts, version: "1" }
+paths:
+  /alerts:
+    get:
+      operationId: listAlerts
+      parameters:
+        - { name: skip, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: array, items: { $ref: "#/components/schemas/Alert" } }
+components:
+  schemas:
+    Alert:
+      type: object
+      properties:
+        id: { type: string }
+`
+
+// TestE2E_BareArrayPagination covers an endpoint that returns the collection
+// directly. Detection looked for the items inside a response object, so an
+// operation whose parameters plainly page got no iterator.
+func TestE2E_BareArrayPagination(t *testing.T) {
+	files, _ := generateFromSpec(t, bareArrayPaginationSpec, "alertsapi")
+
+	runGeneratedWireTest(t, files, "barearray", `package alertsapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIteratesTheResponseItself(t *testing.T) {
+	var asked []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		skip := r.URL.Query().Get("skip")
+		asked = append(asked, skip)
+		bySkip := map[string][]map[string]string{
+			"":  {{"id": "a"}, {"id": "b"}},
+			"2": {{"id": "c"}},
+			"3": {},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(bySkip[skip])
+	}))
+	defer srv.Close()
+
+	all, err := NewClient(srv.URL).ListAlertsIter(t.Context()).All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("items = %d, want 3", len(all))
+	}
+	if all[0].ID == nil || *all[0].ID != "a" || *all[2].ID != "c" {
+		t.Errorf("items = %+v, want a, b, c", all)
+	}
+	if len(asked) != 3 || asked[1] != "2" || asked[2] != "3" {
+		t.Errorf("skips requested = %v, want the first page, then 2, then 3", asked)
+	}
+}
+
+// A page that comes back as JSON null is empty, not a crash.
+func TestNullPageEndsTheWalk(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("null"))
+	}))
+	defer srv.Close()
+
+	all, err := NewClient(srv.URL).ListAlertsIter(t.Context()).All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("items = %d, want none", len(all))
+	}
+}
+`)
+}

--- a/internal/ir/pagination.go
+++ b/internal/ir/pagination.go
@@ -24,6 +24,8 @@ type PaginationDef struct {
 	// Common:
 	HasMoreField string // Response field indicating more pages exist (optional)
 	TotalField   string // Response field with total count (optional)
-	ItemsField   string // Response field containing the items array
+	ItemsField   string // Response field containing the items array, empty when the response is the array
 	ItemsType    string // Go element type of the items array (e.g., "Pet")
+	// ItemsAreResponse marks a response that is the page rather than holding it.
+	ItemsAreResponse bool
 }

--- a/internal/templates/pagination.go.tmpl
+++ b/internal/templates/pagination.go.tmpl
@@ -128,7 +128,14 @@ func (c *Client) {{ $op.Name }}Iter(ctx context.Context{{ range $op.PathParams }
 			if err != nil {
 				return nil, "", err
 			}
+{{- if $op.Pagination.ItemsAreResponse }}
+			var items []{{ paginationItemType $op }}
+			if result != nil {
+				items = *result
+			}
+{{- else }}
 			items := result.{{ toGoName $op.Pagination.ItemsField }}
+{{- end }}
 			if len(items) == 0 {
 				return items, "", nil
 			}


### PR DESCRIPTION
Closes #112.

Detection looked for the items inside a response object:

```go
func findItemsField(byName map[string]*ir.TypeDef, td *ir.TypeDef) itemsFieldInfo
```

An endpoint whose success response is the array has no field to find, so it was never paginated even when its parameters said plainly that it was. Returning the collection directly is an ordinary REST shape: the total and the next link live in headers, or the API simply does not report them.

## Measured

The ACTIVATE spec has roughly 27 operations carrying paging parameters, 10 of which return a bare array. It generated 17 iterators after #110 and now generates **27**, with the client still compiling.

## What this does not need

- **No rule about which array is the page.** The response is the only thing it can be, so #65's caution about guessing does not apply here.
- **No new style.** These are the counting styles, unchanged.
- **Cursor style is untouched**, since a bare array has nowhere to carry a next cursor.

An array a spec names (`AlertList: {type: array, items: ...}`) is the same page behind an alias and is followed through. A response that is neither a page object nor an array is still not paginated.

## Tests

- `internal/analyzer/pagination_test.go`: a bare array response pages over itself with no items field and the right element type, an aliased array behaves the same, and a scalar response is not a page.
- `internal/generator/e2e_bare_array_pagination_test.go`: compiles and runs against `httptest`, walking three pages and checking the requested `skip` values advance by items received, plus a page that arrives as JSON `null`, which ends the walk rather than panicking on a nil dereference.

`gofmt`, `golangci-lint`, `go vet ./...`, and `go test ./...` pass.