### PR TITLE
fix(pagination): a page or offset that is not a number broke the build

### DIFF
--- a/internal/analyzer/pagination.go
+++ b/internal/analyzer/pagination.go
@@ -40,7 +40,9 @@ func (a *Analyzer) detectCursorPagination(op *ir.OperationDef, pkg *ir.Package) 
 	// it sets each page, so a required (value) cursor can't be paginated.
 	cursorParam := ""
 	for _, p := range op.QueryParams {
-		if !p.Required && containsCI(cursorParamNames, p.OrigName) {
+		// The iterator hands the cursor back as the string it received, so a
+		// parameter of another type is not one it can drive.
+		if !p.Required && p.Type == "string" && containsCI(cursorParamNames, p.OrigName) {
 			cursorParam = p.OrigName
 			break
 		}
@@ -82,9 +84,14 @@ func (a *Analyzer) detectCursorPagination(op *ir.OperationDef, pkg *ir.Package) 
 
 // detectOffsetPagination checks if an operation uses offset-based pagination.
 func (a *Analyzer) detectOffsetPagination(op *ir.OperationDef, pkg *ir.Package) *ir.PaginationDef {
+	// Only parameters the iterator can actually count with: it reads the value
+	// as a number and writes the next one back, so a page that carries a token
+	// rather than a count is not a page this can walk.
 	queryNames := make(map[string]string) // lowercase -> origName
 	for _, p := range op.QueryParams {
-		queryNames[strings.ToLower(p.OrigName)] = p.OrigName
+		if isCountingType(p.Type) {
+			queryNames[strings.ToLower(p.OrigName)] = p.OrigName
+		}
 	}
 
 	offsetParam := ""
@@ -239,6 +246,18 @@ func recordArrays(byName map[string]*ir.TypeDef, arrays []*ir.Field) []*ir.Field
 		}
 	}
 	return records
+}
+
+// isCountingType reports whether a parameter holds a number an iterator can
+// advance. The generated code converts through int64, so every integer width
+// qualifies and nothing else does.
+func isCountingType(goType string) bool {
+	switch strings.TrimPrefix(goType, "*") {
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64":
+		return true
+	}
+	return false
 }
 
 // containsCI checks if any element in the list matches the target (case-insensitive).

--- a/internal/analyzer/pagination_test.go
+++ b/internal/analyzer/pagination_test.go
@@ -527,3 +527,77 @@ func TestPagination_BareArrayResponseIsThePage(t *testing.T) {
 		t.Errorf("ListScalar pagination = %+v, want none", scalar)
 	}
 }
+
+const nonNumericPagingSpec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - { name: page, in: query, schema: { type: string, maxLength: 5000 } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+  /counted:
+    get:
+      operationId: counted
+      parameters:
+        - { name: page, in: query, schema: { type: integer, format: int32 } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+  /tokened:
+    get:
+      operationId: tokened
+      parameters:
+        - { name: cursor, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+components:
+  schemas:
+    Page:
+      type: object
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/Item" } }
+        nextCursor: { type: string }
+    Item:
+      type: object
+      properties: { id: { type: string } }
+`
+
+// The generated iterator reads its position as a number and writes the next one
+// back, so a page carrying a token rather than a count is not one it can walk.
+// Stripe's search endpoints declare page as a string, and generating for them
+// produced code that did not compile.
+func TestPagination_ParameterTypesMustMatchTheWalk(t *testing.T) {
+	pkg, _ := analyzeSpec(t, nonNumericPagingSpec)
+
+	byName := map[string]*ir.PaginationDef{}
+	for _, op := range pkg.Operations {
+		byName[op.Name] = op.Pagination
+	}
+
+	if search := byName["Search"]; search != nil {
+		t.Errorf("Search pagination = %+v, want none: its page is a string", search)
+	}
+	counted := byName["Counted"]
+	if counted == nil || counted.Style != ir.PaginationStylePage {
+		t.Errorf("Counted pagination = %+v, want the page style", counted)
+	}
+	// A cursor is handed back as the string it arrived as, so an integer one is
+	// not a cursor this can drive either.
+	if tokened := byName["Tokened"]; tokened != nil && tokened.Style == ir.PaginationStyleCursor {
+		t.Errorf("Tokened pagination = %+v, want no cursor style: its cursor is an integer", tokened)
+	}
+}

--- a/internal/generator/e2e_paging_param_type_test.go
+++ b/internal/generator/e2e_paging_param_type_test.go
@@ -1,0 +1,67 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+)
+
+const stringPageSpec = `openapi: 3.1.0
+info: { title: search, version: "1" }
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - { name: page, in: query, schema: { type: string, maxLength: 5000 } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+  /list:
+    get:
+      operationId: list
+      parameters:
+        - { name: page, in: query, schema: { type: integer } }
+        - { name: limit, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Page" } }
+components:
+  schemas:
+    Page:
+      type: object
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/Item" } }
+    Item:
+      type: object
+      properties:
+        id: { type: string }
+`
+
+// TestE2E_StringPageParamStillCompiles covers a page parameter that carries a
+// token rather than a count, which Stripe's search endpoints declare. The
+// iterator converts its position through int64, so generating one produced a
+// package that did not build.
+func TestE2E_StringPageParamStillCompiles(t *testing.T) {
+	files, _ := generateFromSpec(t, stringPageSpec, "searchapi")
+
+	var pagination string
+	for _, f := range files {
+		if f.Name == "pagination.go" {
+			pagination = string(f.Content)
+		}
+	}
+	if strings.Contains(pagination, "SearchIter") {
+		t.Error("an operation whose page is a string should get no iterator")
+	}
+	if !strings.Contains(pagination, "ListIter") {
+		t.Error("an operation whose page is a number should still get one")
+	}
+
+	// The point of the test: the package builds.
+	buildGenerated(t, files, "stringpage")
+}


### PR DESCRIPTION
Closes #114. Found by generating against Stripe's spec.

```go
at = int64(*p.Page)
```

Stripe's search endpoints declare `page` as a string, because it carries a token:

```json
GET /v1/charges/search   {"maxLength": 5000, "type": "string"}
```

```
./pagination.go:83:16: cannot convert *p.Page (variable of type string) to type int64
... 7 total
```

All 2690 types generated cleanly and the package failed on the iterators alone.

This is a regression from #92: before the counting iterators existed, a string `page` produced no iterator rather than a broken one.

## Fix

A type check rather than a name check, since the names were already right and it is the type the generated code depends on:

- **Counting styles need an integer** to advance. Every integer width qualifies, since the generated code converts through `int64`.
- **Cursor style needs a string** to hand back, which was the same unstated assumption from the other side. No spec I have declares an integer cursor, but the assumption was equally unchecked.

An operation that fails the check keeps its plain method, and the caller passes the token themselves. For a `page` that is not a page number, that is the honest outcome.

## Verified across four real specs

| spec | before | after |
|---|---|---|
| Stripe (416 paths) | 7 iterators, **does not compile** | 0 iterators, compiles |
| ACTIVATE (577 paths) | 27, compiles | 27, compiles |
| Mealie (168 paths) | 30, compiles | 30, compiles |

Stripe drops to zero because its pagination is `starting_after`/`ending_before`, which this generator does not recognize as a cursor. That is a separate gap, and no iterator is better than one that will not build.

## Tests

- `internal/analyzer/pagination_test.go`: a string `page` gets no pagination, an integer `page` still gets the page style, and an integer `cursor` gets no cursor style.
- `internal/generator/e2e_paging_param_type_test.go`: the operation with a string page gets no iterator, the one beside it with a numeric page still does, and the package compiles.

`gofmt`, `golangci-lint`, `go vet ./...`, and `go test ./...` pass.