### PR TITLE
test(generator): pin that generating a spec twice gives the same bytes

### DIFF
--- a/internal/generator/e2e_combinations_test.go
+++ b/internal/generator/e2e_combinations_test.go
@@ -77,6 +77,8 @@ func TestE2E_Combinations(t *testing.T) {
 		{"operations.go", "params.Either", "a union-typed parameter"},
 		{"errors.go", "func (e *ProblemResponse) Error() string", "a typed error wrapper"},
 		{"errors.go", "e.Detail.Detail", "a message field found by its conventional name"},
+		{"errors.go", "func parseFailureResponse", "a second error shape in one package"},
+		{"errors.go", "func parseListAlertsResponse422Error", "an error body with no name of its own"},
 		{"types.go", "Name string `json:\"name\"`", "a property two allOf entries declare, required by one"},
 	} {
 		if !containsCollapsed(byName[want.file], want.decl) {
@@ -98,4 +100,53 @@ func TestE2E_Combinations(t *testing.T) {
 // depend on alignment that has not happened yet.
 func containsCollapsed(haystack, needle string) bool {
 	return strings.Contains(strings.Join(strings.Fields(haystack), " "), strings.Join(strings.Fields(needle), " "))
+}
+
+// TestGenerationIsDeterministic generates one spec twice and compares the bytes.
+// Generated clients are committed and reviewed, so output that shifts between
+// runs shows up as churn in a diff nobody made, and the usual cause is a map
+// iterated somewhere on the way out.
+func TestGenerationIsDeterministic(t *testing.T) {
+	specPath := filepath.Join(projectRoot(), "testdata", "combinations.yaml")
+
+	generate := func() map[string]string {
+		t.Helper()
+		result, err := parser.Parse(specPath, parser.Config{})
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		pkg, err := analyzer.New(result.Model).Analyze("combinations")
+		if err != nil {
+			t.Fatalf("Analyze: %v", err)
+		}
+		gen, err := New(pkg)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		files, err := gen.Generate()
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		out := make(map[string]string, len(files))
+		for _, f := range files {
+			out[f.Name] = string(f.Content)
+		}
+		return out
+	}
+
+	first, second := generate(), generate()
+
+	if len(first) != len(second) {
+		t.Fatalf("file counts differ: %d and %d", len(first), len(second))
+	}
+	for name, content := range first {
+		other, ok := second[name]
+		if !ok {
+			t.Errorf("%s was generated once and not the other time", name)
+			continue
+		}
+		if content != other {
+			t.Errorf("%s differs between two runs of the same spec", name)
+		}
+	}
 }

--- a/testdata/combinations.yaml
+++ b/testdata/combinations.yaml
@@ -95,6 +95,15 @@ paths:
           content:
             application/json:
               schema: { type: array, items: { $ref: "#/components/schemas/Alert" } }
+        "422":
+          description: An error body with no name of its own.
+          content:
+            application/json:
+              schema: { type: array, items: { type: string } }
+        default:
+          description: A second named error shape, so the package holds more than one.
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/Failure" } }
   /reports:
     get:
       operationId: listReports
@@ -213,6 +222,11 @@ components:
             "^x-": { type: string }
         refined: { $ref: "#/components/schemas/Refined" }
       required: [id]
+    Failure:
+      type: object
+      properties:
+        code: { type: integer }
+        message: { type: string }
     Problem:
       type: object
       properties:


### PR DESCRIPTION
Generated clients are committed and reviewed, so output that shifts between runs shows up as churn in a diff nobody made. Nothing held that property, and the usual way to lose it is a map iterated on the way out.

`TestGenerationIsDeterministic` generates the corpus spec twice and compares the bytes.

## The corpus needed enriching for the guard to mean anything

My first version passed while I was actively sabotaging the generator: I made `uniqueErrorTypes` round-trip through a map, and the test still passed, because the corpus had exactly one error type and iterating a one-entry map is stable however it is written.

The corpus now declares a second named error shape and one with no name of its own, and the same sabotage fails the test:

```
e2e_combinations_test.go:149: errors.go differs between two runs of the same spec
```

Both new error shapes also exercise paths worth having in the corpus: a second wrapper in one package, and the operation-derived naming from #61 for a body with no type name.

## Current state

Generation is already deterministic: ACTIVATE, GitHub, Stripe, Mealie, and the corpus each produce byte-identical output across repeated runs, so this adds no fix. It stops the property from being lost quietly.

`gofmt`, `golangci-lint`, `go vet ./...`, and `go test ./...` pass.